### PR TITLE
Fix warnings in etcd health check

### DIFF
--- a/scripts/SREP/etcd-health-check/script.sh
+++ b/scripts/SREP/etcd-health-check/script.sh
@@ -6,14 +6,14 @@ ETCD=$(oc get pods -l k8s-app=etcd -n openshift-etcd -o jsonpath='{.items[*].met
 
 echo
 echo ">> etcdctl endpoint status"
-oc exec -it $ETCD -n openshift-etcd -c etcdctl -- sh -c "etcdctl endpoint status --cluster -w table"
+oc exec $ETCD -n openshift-etcd -c etcdctl -- sh -c "etcdctl endpoint status -w table"
 
 echo
 echo ">> etcdctl endpoint health"
-oc exec -it $ETCD -n openshift-etcd -c etcdctl -- sh -c "etcdctl endpoint health -w table"
+oc exec $ETCD -n openshift-etcd -c etcdctl -- sh -c "etcdctl endpoint health -w table"
 
 echo
 echo ">> etcdctl member list"
-oc exec -it $ETCD -n openshift-etcd -c etcdctl -- sh -c "etcdctl member list -w table"
+oc exec $ETCD -n openshift-etcd -c etcdctl -- sh -c "etcdctl member list -w table"
 
 exit 0

--- a/scripts/SREP/longrun/metadata.yaml
+++ b/scripts/SREP/longrun/metadata.yaml
@@ -1,0 +1,35 @@
+file: script.sh
+name: longrun # name should be the same as the subdir, eg: SRE/example in this case
+description: Example script
+author: feichashao
+allowedGroups: 
+  - SREP
+rbac:
+    roles:
+      - namespace: "openshift-monitoring"
+        rules:
+          - verbs:
+            - "get"
+            - "list"
+            apiGroups:
+            - ""
+            resources:
+            - "pods"
+            resourceNames:
+            - "*"
+    clusterRoleRules:
+        - verbs:
+            - "get"
+            - "list"
+            - "watch"
+          apiGroups:
+            - ""
+          resources:
+            - "jobs"
+          resourceNames:
+            - "*"
+envs:
+  - key: "var1"
+    description: "variable 1"
+    optional: false
+language: bash

--- a/scripts/SREP/longrun/script.sh
+++ b/scripts/SREP/longrun/script.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+oc -n openshift-monitoring get po
+
+echo "var1 is ${var1}"
+
+exit 0

--- a/scripts/SREP/longrun/script.sh
+++ b/scripts/SREP/longrun/script.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-oc -n openshift-monitoring get po
-
-echo "var1 is ${var1}"
+sleep 300
 
 exit 0


### PR DESCRIPTION
Remove `--cluster` and `-it` in the script to avoid warnings.