### PR TITLE
OSD-8555 allow CEE to read node-logs

### DIFF
--- a/scripts/SREP/node-logs/metadata.yaml
+++ b/scripts/SREP/node-logs/metadata.yaml
@@ -1,0 +1,23 @@
+file: script.sh
+name: node-logs
+description: read the node logs. Restrict specific logs of oc adm node-logs.
+author: feichashao
+allowedGroups:
+  - SREP
+  - CSSRE
+  - CEE
+  - MTSRE
+rbac:
+    clusterRoleRules:
+        - verbs:
+            - "get"
+          apiGroups:
+            - ""
+          resources:
+            - "nodes"
+            - "nodes/proxy"
+envs:
+  - key: "node"
+    description: "node name"
+    optional: false
+language: bash

--- a/scripts/SREP/node-logs/script.sh
+++ b/scripts/SREP/node-logs/script.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+set -o pipefail
+
+## validate input
+if [[ -z "$node" ]]
+then
+    echo 'Variable node cannot be blank please try again'
+    exit 1
+fi
+
+if ! [[ "$node" =~ ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$ ]]
+then
+    echo "The node name must be valid hostname"
+    exit 1
+fi
+
+## get the journal of that node
+oc adm node-logs $node
+
+exit 0

--- a/scripts/SREP/node-logs/script.sh
+++ b/scripts/SREP/node-logs/script.sh
@@ -7,17 +7,17 @@ set -o pipefail
 ## validate input
 if [[ -z "$node" ]]
 then
-    echo 'Variable node cannot be blank please try again'
+    echo 'Variable node cannot be blank'
     exit 1
 fi
 
 if ! [[ "$node" =~ ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$ ]]
 then
-    echo "The node name must be valid hostname"
+    echo "The node name must be a valid hostname"
     exit 1
 fi
 
 ## get the journal of that node
-oc adm node-logs $node
+oc adm node-logs "$node"
 
 exit 0


### PR DESCRIPTION
Allow CEE to read node-logs.

The permission `nodes/proxy` is too wide, so we use a wrapper managed-script to allow them to read journal log on that node only.