### PR TITLE
get-targets-down: Use internal prometheus domain name

### DIFF
--- a/scripts/SREP/get-targets-down/metadata.yaml
+++ b/scripts/SREP/get-targets-down/metadata.yaml
@@ -14,12 +14,6 @@ rbac:
           - verbs:
             - "get"
             apiGroups:
-            - "route.openshift.io"
-            resources:
-            - "routes"
-          - verbs:
-            - "get"
-            apiGroups:
             - ""
             resources:
             - "serviceaccounts"

--- a/scripts/SREP/get-targets-down/script.sh
+++ b/scripts/SREP/get-targets-down/script.sh
@@ -3,9 +3,8 @@
 set -euo pipefail
 
 TOKEN="$(oc -n openshift-monitoring sa get-token prometheus-k8s)"
-PROMETHEUS_HOST="$(oc -n openshift-monitoring get route prometheus-k8s -o jsonpath='{.spec.host}')"
 
-TARGETS_JSON="$(curl -G -s -k -H "Authorization: Bearer $TOKEN" "https://$PROMETHEUS_HOST/api/v1/targets")"
+TARGETS_JSON="$(curl -G -s -k -H "Authorization: Bearer $TOKEN" "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091/api/v1/targets")"
 TARGETS_DOWN="$(jq -r '.data.activeTargets[] | select(.health=="down") | .labels.pod' <<< "$TARGETS_JSON")"
 
 echo "Targets down:"


### PR DESCRIPTION
* In some cases, the route domain name cannot be resolved

jira: [OSD-8685](https://issues.redhat.com/browse/OSD-8685)