### PR TITLE
Add get Kafka instance state script

### DIFF
--- a/scripts/managed-services/get-kafka-instance-state/get-kafka-instance-state.sh
+++ b/scripts/managed-services/get-kafka-instance-state/get-kafka-instance-state.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -o nounset
+set -o pipefail
+
+function main() {
+  local timestamp
+  timestamp=$(date +%s)
+  local inspectDir
+  inspectDir="inspect.${resource_namespace}.${timestamp}"
+  mkdir "${inspectDir}"
+
+  if ! oc get namespace "${resource_namespace}" &> /dev/null; then
+      echo "No namespace found with name ${resource_namespace}" > "${inspectDir}"/failed.txt
+      # Streaming tar.gz so that the output is in the expected format, even in this failure case
+      tar zcf - ./"${inspectDir}"
+      return 1
+  fi
+
+  local managedKafkaCR
+  managedKafkaCR=$(oc -n "${resource_namespace}" get managedkafka -o name)
+  local kafkaCR
+  kafkaCR=$(oc -n "${resource_namespace}" get kafka -o name)
+  local kafkaStatefulSet
+  kafkaStatefulSet=$(oc -n "${resource_namespace}" get statefulset -l app.kubernetes.io/name=kafka -o name)
+
+  oc -n "${resource_namespace}" adm inspect ns/"${resource_namespace}" "${managedKafkaCR}" "${kafkaCR}" \
+    --dest-dir "${inspectDir}" > "${inspectDir}"/ocadm.log 2>&1
+
+  oc exec -n "${resource_namespace}" "${kafkaStatefulSet}" -c kafka -- sh /opt/kafka/bin/kafka-topics.sh \
+    --bootstrap-server localhost:9096 --list > "${inspectDir}"/kafka-topics.txt 2>&1
+
+  oc exec -n "${resource_namespace}" "${kafkaStatefulSet}" -c kafka -- sh /opt/kafka/bin/kafka-consumer-groups.sh \
+    --bootstrap-server localhost:9096 --all-groups --describe  > "${inspectDir}"/kafka-consumer-groups.txt 2>&1
+
+  oc exec -n "${resource_namespace}" "${kafkaStatefulSet}" -c kafka -- sh /opt/kafka/bin/kafka-acls.sh \
+    --bootstrap-server localhost:9096 --list > "${inspectDir}"/kafka-acls.txt 2>&1
+
+  find "${inspectDir}" -type f -name secrets.yaml -delete
+
+  find "${inspectDir}" -path '*/managedkafkas/*' -name "*.yaml" -exec sed -i '/password:/d' {} \;
+
+  tar zcf - ./"${inspectDir}"
+}
+
+main

--- a/scripts/managed-services/get-kafka-instance-state/metadata.yaml
+++ b/scripts/managed-services/get-kafka-instance-state/metadata.yaml
@@ -1,0 +1,48 @@
+file: get-kafka-instance-state.sh
+name: get-kafka-instance-state
+description: |
+  Print out the logs for the specified Kafka instance.
+  The following commands will create a directory with all instance information:
+
+  ocm backplane managedjob logs <job-name> > mykafkadebug.tar.gz
+  tar -xvf mykafkadebug.tar.gz
+author: racheljpg
+allowedGroups:
+  - SREP
+  - CSSRE
+  - CEE
+rbac:
+  roles:
+    - namespace: "default"
+      rules:
+        - verbs:
+            - "get"
+            - "list"
+          apiGroups:
+            - ""
+          resources:
+            - "pods/exec"
+        - verbs:
+            - "create"
+          apiGroups:
+            - ""
+          resources:
+            - "pods/exec"
+      clusterRoleRules:
+        - verbs:
+            - "adm"
+          apiGroups:
+            - ""
+          resources:
+            - "inspect"
+        - verbs:
+            - "create"
+          apiGroups:
+            - ""
+          resources:
+            - "pods/exec"
+envs:
+  - key: "resource_namespace"
+    description: "Namespace for the Kafka instance you want to query"
+    optional: false
+language: bash


### PR DESCRIPTION
This PR is to add a script and accompanying metadata file that can be ran against a single Kafka instance and will then return a tar stream of all the logs/events/CRs in the instance.