### PR TITLE
Add missing permissions to kafka-instances script

### DIFF
--- a/scripts/CEE/get-kafka-instance-state/metadata.yaml
+++ b/scripts/CEE/get-kafka-instance-state/metadata.yaml
@@ -42,6 +42,19 @@ rbac:
           resources:
             - "pods/exec"
         - verbs:
+            - "get"
+            - "list"
+          apiGroups:
+            - "apps"
+          resources:
+            - "statefulsets"
+        - verbs:
+            - "get"
+          apiGroups:
+            - ""
+          resources:
+            - ""
+        - verbs:
             - "list"
           apiGroups:
             - "managedkafka.bf2.org"

--- a/scripts/CEE/get-kafka-instance-state/metadata.yaml
+++ b/scripts/CEE/get-kafka-instance-state/metadata.yaml
@@ -53,7 +53,7 @@ rbac:
           apiGroups:
             - ""
           resources:
-            - ""
+            - "pods"
         - verbs:
             - "list"
           apiGroups:


### PR DESCRIPTION
statefulset and pod permissions were absent, this caused the commands that query kafka state to fail.