### PR TITLE
Add optional since/since-time flags as environment variables

### DIFF
--- a/scripts/CEE/get-kafka-instance-state/get-kafka-instance-state.sh
+++ b/scripts/CEE/get-kafka-instance-state/get-kafka-instance-state.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -o nounset
 set -o pipefail
 
 function main() {
@@ -23,8 +22,16 @@ function main() {
   local kafkaStatefulSet
   kafkaStatefulSet=$(oc -n "${resource_namespace}" get statefulset -l app.kubernetes.io/name=kafka -o name)
 
-  oc -n "${resource_namespace}" adm inspect ns/"${resource_namespace}" "${managedKafkaCR}" "${kafkaCR}" \
-    --dest-dir "${inspectDir}" > "${inspectDir}"/ocadm.log 2>&1
+  if [[ -v since ]]; then
+      oc -n "${resource_namespace}" adm inspect ns/"${resource_namespace}" "${managedKafkaCR}" "${kafkaCR}" \
+        --since "${since}" --dest-dir "${inspectDir}" > "${inspectDir}"/ocadm.log 2>&1
+  elif [[ -v since_time ]]; then
+     oc -n "${resource_namespace}" adm inspect ns/"${resource_namespace}" "${managedKafkaCR}" "${kafkaCR}" \
+        --since-time "${since_time}" --dest-dir "${inspectDir}" > "${inspectDir}"/ocadm.log 2>&1
+  else
+     oc -n "${resource_namespace}" adm inspect ns/"${resource_namespace}" "${managedKafkaCR}" "${kafkaCR}" \
+        --dest-dir "${inspectDir}" > "${inspectDir}"/ocadm.log 2>&1
+  fi
 
   oc exec -n "${resource_namespace}" "${kafkaStatefulSet}" -c kafka -- sh /opt/kafka/bin/kafka-topics.sh \
     --bootstrap-server localhost:9096 --list > "${inspectDir}"/kafka-topics.txt 2>&1

--- a/scripts/CEE/get-kafka-instance-state/get-kafka-instance-state.sh
+++ b/scripts/CEE/get-kafka-instance-state/get-kafka-instance-state.sh
@@ -23,7 +23,7 @@ function main() {
   local kafkaStatefulSet
   kafkaStatefulSet=$(oc -n "${resource_namespace}" get statefulset -l app.kubernetes.io/name=kafka -o name)
 
-  inspectOps=(ns/"${resource_namespace}" "${managedKafkaCR}" "${kafkaCR}")
+  inspectOps=(ns/"${resource_namespace}" "${managedKafkaCR}" "${kafkaCR}" --dest-dir "${inspectDir}")
 
   if [[ -v since ]]; then
       inspectOps+=("--since=${since}")
@@ -31,7 +31,7 @@ function main() {
       inspectOps+=("--since-time=${since_time}")
   fi
 
-  oc -n "${resource_namespace}" adm inspect "${inspectOps[@]}" --dest-dir "${inspectDir}" > "${inspectDir}"/ocadm.log 2>&1
+  oc -n "${resource_namespace}" adm inspect "${inspectOps[@]}" > "${inspectDir}"/ocadm.log 2>&1
 
   oc exec -n "${resource_namespace}" "${kafkaStatefulSet}" -c kafka -- sh /opt/kafka/bin/kafka-topics.sh \
     --bootstrap-server localhost:9096 --list > "${inspectDir}"/kafka-topics.txt 2>&1

--- a/scripts/CEE/get-kafka-instance-state/metadata.yaml
+++ b/scripts/CEE/get-kafka-instance-state/metadata.yaml
@@ -70,5 +70,10 @@ envs:
   - key: "resource_namespace"
     description: "Namespace for the Kafka instance you want to query"
     optional: false
+  - key: "since"
+    description: "This is being passed to use the --since flag used by oc adm inspect. Only one of since-time/since may be used"
+    optional: true
+  - key: "since_time"
+    description: "This is being passed to use the --since-time flag used by oc adm inspect. Only one of since-time/since may be used"
+    optional: true
 language: bash
-

--- a/scripts/CEE/get-kafka-instance-state/metadata.yaml
+++ b/scripts/CEE/get-kafka-instance-state/metadata.yaml
@@ -74,6 +74,6 @@ envs:
     description: "This is being passed to use the --since flag used by oc adm inspect. Only one of since-time/since may be used"
     optional: true
   - key: "since_time"
-    description: "This is being passed to use the --since-time flag used by oc adm inspect. Only one of since-time/since may be used"
+    description: "This is being passed to use the --since-time flag used by oc adm inspect. Timestamp is in RFC 3339 format. Only one of since-time/since may be used"
     optional: true
 language: bash


### PR DESCRIPTION
This is a PR to make an edit to the get-kafka-instance-state script to allow optional since/since-time flags to be specified.