### PR TITLE
OSD-8688 Add cluster-operator-status script

### DIFF
--- a/scripts/SREP/cluster-operator-status/README.md
+++ b/scripts/SREP/cluster-operator-status/README.md
@@ -1,0 +1,44 @@
+# Cluster Operator Status
+
+## Description
+
+This script provides a rich summary of information concerning the status of degraded/unavailable OpenShift cluster operators:
+
+- Basic summary (Degraded / Progressing / Available state)
+- Detailed summary (Description)
+- Namespace inspection (Status of all pods in each of the cluster operator's related namespaces)
+- Operator logs (Most recent 15 lines of logging from the operator deployment pod)
+
+## Usage
+
+The script can target a specific cluster operator through the use of the `CLUSTER_OPERATOR` environment variable / backplane parameter.
+
+If the `CLUSTER_OPERATOR` environment variable is empty or not set, the script will by default target all degraded or unavailable cluster operators.
+
+```bash
+ocm backplane managedjob create SREP/cluster-operator-status 
+
+or
+
+ocm backplane managedjob create SREP/cluster-operator-status -p CLUSTER_OPERATOR=machine-config
+```
+
+The script can adjust the time interval of logging retrieved through the use of the `OC_LOGS_SINCE` parameter. The interval can be in the form of `<duration>` followed by a unit such as `s` for seconds, `m` for minutes or `h` for hours. When specified, the last `<duration>` worth of logs are retrieved.
+
+If no value is specified, the last 15 lines of logging are retrieved instead.
+
+Examples:
+
+```bash
+OC_LOGS_SINCE="30s"
+OC_LOGS_SINCE="30m"
+```
+
+The script can also filter what logging is retrieved through the # use of the `LOG_PATTERN` parameter. This parameter defines an 
+extended regular expression passed to grep to filter logs after being returned from 'oc logs'.
+
+Example:
+
+```bash
+LOG_PATTERN="error|warning"
+```

--- a/scripts/SREP/cluster-operator-status/metadata.yaml
+++ b/scripts/SREP/cluster-operator-status/metadata.yaml
@@ -1,0 +1,44 @@
+file: script.sh
+name: cluster-operator-status # name should be the same as the subdir, eg: SRE/example in this case
+description: Retrieve status of the cluster's Cluster Operators
+author: mbargenq
+allowedGroups: 
+  - SREP
+  - CSSRE
+  - CEE
+  - MTSRE
+rbac:
+    roles: []
+    clusterRoleRules:
+    - verbs:
+      - "get"
+      - "list"
+      apiGroups:
+      - "config.openshift.io"
+      resources:
+      - clusteroperators
+    - verbs:
+      - "get"
+      - "list"
+      apiGroups:
+      - "apps"
+      resources:
+      - deployments
+    - verbs:
+      - "get"
+      - "list"
+      apiGroups:
+      - ""
+      resources:
+      - pods
+envs:
+  - key: "CLUSTER_OPERATOR"
+    description: "Cluster Operator to specifically target."
+    optional: true
+  - key: "OC_LOGS_SINCE"
+    description: "Specify the time interval history of logs to retrieve (eg. 60s, 1m, 30m)."
+    optional: true
+  - key: "LOG_PATTERN"
+    description: "Extended regular expression pattern used for log filtering."
+    optional: true
+language: bash

--- a/scripts/SREP/cluster-operator-status/script.sh
+++ b/scripts/SREP/cluster-operator-status/script.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# This script provides a rich summary of information concerning the status of 
+# degraded/unavailable OpenShift cluster operators.
+#
+# The script can specifically target a cluster operator through
+# the use of a "CLUSTER_OPERATOR" parameter
+#
+# The script can adjust the time interval of logging retrieved through the
+# use of the OC_LOGS_SINCE parameter. This parameter can define
+# additional options supplied to 'oc logs' when gathering pod logs.
+#
+# The script can also filter what logging is retrieved through the
+# use of the LOG_PATTERN parameter. This parameter defines an 
+# extended regular expression passed to grep to filter logs
+# after being returned from 'oc logs'
+#
+set -e
+set -o nounset
+set -o pipefail
+
+
+# print_header prints a formatted section break header
+print_header() {
+    clusteroperator=$1
+    heading=$2
+    echo -e "--- [ CLUSTER OPERATOR '${clusteroperator}' ${heading} ] ---\n"
+}
+
+# get_summary prints the basic status for the given cluster operator parameter
+get_summary() {
+    clusteroperator=$1
+
+    # shellcheck disable=SC2016
+    available=$(jq -r --arg CLUSTER_OPERATOR "${clusteroperator}" '.items[] | select(.metadata.name == $CLUSTER_OPERATOR) | .status.conditions[] | select(.type == "Available") | "\(.status) --> \(.message)"' <<< "$OPERATOR_REPORT")
+    # shellcheck disable=SC2016
+    progressing=$(jq -r --arg CLUSTER_OPERATOR "${clusteroperator}" '.items[] | select(.metadata.name == $CLUSTER_OPERATOR) | .status.conditions[] | select(.type == "Progressing") | "\(.status) --> \(.message)"' <<< "$OPERATOR_REPORT")
+    # shellcheck disable=SC2016
+    degraded=$(jq -r --arg CLUSTER_OPERATOR "${clusteroperator}" '.items[] | select(.metadata.name == $CLUSTER_OPERATOR) | .status.conditions[] | select(.type == "Degraded") | "\(.status) --> \(.message)"' <<< "$OPERATOR_REPORT")
+
+    print_header "${clusteroperator}" "SUMMARY"
+    echo " - AVAILABLE:   ${available}"
+    echo " - DEGRADED:    ${degraded}"
+    echo " - PROGRESSING: ${progressing}"
+    echo -e "\n"
+}
+
+# get_description prints a detailed status description for the given cluster 
+# operator parameter
+get_description() {
+    clusteroperator=$1
+
+    if ! co_desc_report=$(oc describe clusteroperator "${clusteroperator}"); then
+       echo "An error was returned when describing ClusterOperator '${clusteroperator}': ${co_desc_report}"
+       return
+    fi
+    print_header "${clusteroperator}" "DESCRIPTION"
+    echo -e "${co_desc_report}\n\n"
+}
+
+# get_logs prints the last 15 lines of logs from the cluster operator pod
+get_logs() {
+    clusteroperator=$1
+    # Look up all namespaces referenced in status
+    # shellcheck disable=SC2016
+    relatedns=$(jq -r --arg CLUSTER_OPERATOR "${clusteroperator}" '.items[] | select(.metadata.name == $CLUSTER_OPERATOR) | .status.relatedObjects[] | select(.resource == "namespaces") | .name' <<< "$OPERATOR_REPORT")
+    while IFS= read -r ns; do
+        ns_report=$(oc get deployment --ignore-not-found -n "$ns" -o name)
+        while IFS= read -r deployment; do
+            # Look for any deployment which matches an operator deployment.
+            # The cluster operator name may or may not have the word operator in it.
+            # The cluster operator namespaces may or may not unrelated operator pods in them.
+            if [[ "${deployment}" =~ ${clusteroperator} && "${deployment}${clusteroperator}" =~ operator ]]; then
+                # deploymentlogs=$(log_cmd "${deployment}" "${ns}")
+                if [[ -n "${LOG_PATTERN}" ]]; then
+                    # shellcheck disable=SC2046
+                    deploymentlogs=$(grep -iE "${LOG_PATTERN}" <<< $(oc logs "${deployment}" -n "${ns}" --all-containers "${OC_LOGS_SINCE}") || true)
+                else 
+                    deploymentlogs=$(oc logs "${deployment}" -n "${ns}" --all-containers "${OC_LOGS_SINCE}")
+                fi
+                print_header "${clusteroperator}" "DEPLOYMENT LOGS: ${deployment}"
+                echo -e "${deploymentlogs}\n\n"
+            fi
+        done <<< "${ns_report}"
+    done <<< "${relatedns}"
+}
+
+# inspect_namespace prints the status of pods running in each namespace 
+# that the cluster operator is concerned with
+inspect_namespace() {
+    clusteroperator=$1
+
+    # Look up all namespaces referenced in status
+    # shellcheck disable=SC2016
+    relatedns=$(jq -r --arg CLUSTER_OPERATOR "${clusteroperator}" '.items[] | select(.metadata.name == $CLUSTER_OPERATOR) | .status.relatedObjects[] | select(.resource == "namespaces") | .name' <<< "$OPERATOR_REPORT")
+    while IFS= read -r ns; do
+        ns_report=$(oc get pod --ignore-not-found -n "$ns")
+        if [[ -n "${ns_report}" ]]; then
+            print_header "$clusteroperator" "NAMESPACE: ${ns}"
+            echo -e "${ns_report}\n\n"
+        fi
+    done <<< "${relatedns}"
+}
+
+# Set defaults for retrieving and filtering logs
+OC_LOGS_SINCE="${OC_LOGS_SINCE:-}"
+if [[ -n "${OC_LOGS_SINCE}" ]]; then
+    OC_LOGS_SINCE="--since=${OC_LOGS_SINCE}"
+else
+    OC_LOGS_SINCE="--tail=15"
+fi
+LOG_PATTERN="${LOG_PATTERN:-}"
+
+# Retrieve the full ClusterOperator status report
+if ! OPERATOR_REPORT=$(oc get clusteroperator -o json); then 
+    echo "An error was returned when reading ClusterOperator status: ${OPERATOR_REPORT}"
+    exit 1
+fi
+if [[ -z "${OPERATOR_REPORT}" ]]; then
+    echo "No ClusterOperator status was returned."
+    exit 1
+fi
+
+# Get list of degraded or unavailable operators
+CLUSTER_OPERATOR="${CLUSTER_OPERATOR:-}"
+if [[ -z "${CLUSTER_OPERATOR}" ]]; then
+    # shellcheck disable=SC2016
+    CLUSTER_OPERATOR=$(jq -r '.items[] | .metadata as $m | .status.conditions[] | select ((.type == "Degraded" or .type == "Unavailable") and (.status == "True")) | $m.name' <<< "$OPERATOR_REPORT")
+    echo "No CLUSTER_OPERATOR parameter specified. Will summarize all degraded or unavailable cluster operators:"
+    echo -e "${CLUSTER_OPERATOR}\n\n"
+fi
+
+while IFS= read -r co; do
+    get_summary "${co}"
+    get_description "${co}"
+    inspect_namespace "${co}"
+    get_logs "${co}"
+done <<< "${CLUSTER_OPERATOR}"


### PR DESCRIPTION
Refs: [OSD-8688](https://issues.redhat.com/browse/OSD-8688)

This PR adds a `cluster-operator-status` managed script script to gather data on degraded or unavailable cluster operators.

It can optionally target a specific cluster operator via the `CLUSTER_OPERATOR` parameter.

Successfully tested via `ocm backplane testjob create`. (An easy scenario to test against that quickly simulates cluster operator failures is to cordon and drain a master node.)