### PR TITLE
Added scripts to get kafka topics

### DIFF
--- a/scripts/CSSRE/get-kafka-topics/README.md
+++ b/scripts/CSSRE/get-kafka-topics/README.md
@@ -1,0 +1,32 @@
+# get-kafka-topics
+
+This scripts runs the `kafka-topics.sh` script built into Kafka brokers to provide details of the Kafka's topics and partitions.
+
+## Usage
+
+### Running locally
+
+```bash
+Usage: ./get-kafka-topics.sh -n KAFKA_NAMESPACE [-t TOPIC] [-f <under-replicated-partitions|under-min-isr-partitions|unavailable-partitions>]
+
+# Examples
+./get-kafka-topics.sh -n my-kafka
+./get-kafka-topics.sh -n my-kafka -t canary
+./get-kafka-topics.sh -n my-kafka -t canary -f under-replicated-partitions
+```
+
+### Running as managed script
+
+For use as a managed script, parameters are passed as environment variables.
+
+```bash
+ocm backplane managedjob create CSSRE/get-kafka-topics -p kafka_namespace=<KAFKA_NAMESPACE> [topic=TOPIC] [filter=<under-replicated-partitions|under-min-isr-partitions|unavailable-partitions>]
+
+# Examples
+ocm backplane managedjob create CSSRE/get-kafka-topics -p kafka_namespace=my-kafka
+ocm backplane managedjob create CSSRE/get-kafka-topics -p kafka_namespace=my-kafka topic=canary
+ocm backplane managedjob create CSSRE/get-kafka-topics -p kafka_namespace=my-kafka topic=canary filter=unavailable-partitions
+```
+
+
+

--- a/scripts/CSSRE/get-kafka-topics/get-kafka-topics.sh
+++ b/scripts/CSSRE/get-kafka-topics/get-kafka-topics.sh
@@ -11,7 +11,7 @@ while getopts ":n:t:f:" opt; do
     f) filter="${OPTARG}"
     ;;
     \?)
-    echo $usage
+    echo "$usage"
     exit 1
     ;;
     :) echo "Option -$OPTARG requires an argument" >&2
@@ -19,7 +19,7 @@ while getopts ":n:t:f:" opt; do
   esac
 done
 
-if [ -z ${kafka_namespace} ]; then
+if [ -z "$kafka_namespace" ]; then
   echo -e "Namespace required\n$usage" >&2
   exit 1
 fi
@@ -28,7 +28,7 @@ if [ "$filter" != "" ] && [ "${filter}" != "under-replicated-partitions" ] && [ 
   echo -e "Invalid filter\n$usage" >&2
   exit 1
 else 
-  filter="--${filter}"
+  filter="--$filter"
 fi
 
 echo "Namespace: $kafka_namespace"
@@ -38,13 +38,13 @@ echo -e "Filter: $filter\n"
 function main() {
   echo "Getting kafka topics"
   
-  kafka_cluster=$(oc -n ${kafka_namespace} get kafka --no-headers | awk '{print $1}')
+  kafka_cluster=$(oc -n "$kafka_namespace" get kafka --no-headers | awk '{print $1}')
   echo "Kafka cluster: ${kafka_cluster}"
 
-  if [ -z ${topic} ]; then
-    oc -n ${kafka_namespace} exec -it statefulset/${kafka_cluster}-kafka -c kafka -- env - bin/kafka-topics.sh --bootstrap-server localhost:9096 --describe ${filter}
+  if [ -z "$topic" ]; then
+    oc -n "$kafka_namespace" exec -it statefulset/"$kafka_cluster"-kafka -c kafka -- env - bin/kafka-topics.sh --bootstrap-server localhost:9096 --describe "$filter"
   else
-    oc -n ${kafka_namespace} exec -it statefulset/${kafka_cluster}-kafka -c kafka -- env - bin/kafka-topics.sh --bootstrap-server localhost:9096 --describe --topic ${topic} ${filter}
+    oc -n "$kafka_namespace" exec -it statefulset/"$kafka_cluster"-kafka -c kafka -- env - bin/kafka-topics.sh --bootstrap-server localhost:9096 --describe --topic "$topic" "$filter"
   fi
 }
 

--- a/scripts/CSSRE/get-kafka-topics/get-kafka-topics.sh
+++ b/scripts/CSSRE/get-kafka-topics/get-kafka-topics.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+usage="Usage: $0 -n KAFKA_NAMESPACE [-t TOPIC] [-f <under-replicated-partitions|under-min-isr-partitions|unavailable-partitions>]"
+
+while getopts ":n:t:f:" opt; do
+  case $opt in
+    n) kafka_namespace="${OPTARG}"
+    ;;
+    t) topic="${OPTARG}"
+    ;;
+    f) filter="${OPTARG}"
+    ;;
+    \?)
+    echo $usage
+    exit 1
+    ;;
+    :) echo "Option -$OPTARG requires an argument" >&2
+    exit 1
+  esac
+done
+
+if [ -z ${kafka_namespace} ]; then
+  echo -e "Namespace required\n$usage" >&2
+  exit 1
+fi
+
+if [ "$filter" != "" ] && [ "${filter}" != "under-replicated-partitions" ] && [ "$filter" != "under-min-isr-partitions" ] && [ "$filter" != "unavailable-partitions" ]; then
+  echo -e "Invalid filter\n$usage" >&2
+  exit 1
+else 
+  filter="--${filter}"
+fi
+
+echo "Namespace: $kafka_namespace"
+echo "Topic: $topic"
+echo -e "Filter: $filter\n"
+
+function main() {
+  echo "Getting kafka topics"
+  
+  kafka_cluster=$(oc -n ${kafka_namespace} get kafka --no-headers | awk '{print $1}')
+  echo "Kafka cluster: ${kafka_cluster}"
+
+  if [ -z ${topic} ]; then
+    oc -n ${kafka_namespace} exec -it statefulset/${kafka_cluster}-kafka -c kafka -- env - bin/kafka-topics.sh --bootstrap-server localhost:9096 --describe ${filter}
+  else
+    oc -n ${kafka_namespace} exec -it statefulset/${kafka_cluster}-kafka -c kafka -- env - bin/kafka-topics.sh --bootstrap-server localhost:9096 --describe --topic ${topic} ${filter}
+  fi
+}
+
+main

--- a/scripts/CSSRE/get-kafka-topics/metadata.yaml
+++ b/scripts/CSSRE/get-kafka-topics/metadata.yaml
@@ -1,0 +1,46 @@
+file: get-kafka-topics.sh
+name: get-kafka-topics
+description: |
+  Get topics and partitions details for a given Kafka
+author: Rob Shelly
+allowedGroups:
+  - CSSRE
+rbac:
+  clusterRoleRules:
+    - verbs:
+        - "create"
+      apiGroups:
+        - ""
+      resources:
+        - "pods/exec"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "apps"
+      resources:
+        - "statefulsets"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - ""
+      resources:
+        - "pods"
+    - verbs:
+        - "list"
+      apiGroups:
+        - "kafka.strimzi.io"
+      resources:
+        - "kafkas"
+envs:
+  - key: "kafka_namespace"
+    description: "Namespace for the Kafka instance you want to query"
+    optional: false
+  - key: "topic"
+    description: "A specific topic to show"
+    optional: true
+  - key: "filter"
+    description: "Filter to show only partition "
+    optional: true
+language: bash


### PR DESCRIPTION
Added a script that runs the `kafka-topics.sh` scripts that is built into Kafka pods. It's used to get details of Kafka topics and partitions and also filter by under replicated, under min ISR or offline partitions. 