### PR TITLE
Rename get-rhosak-operators to match directory

### DIFF
--- a/scripts/CEE/get-rhosak-operators/metadata.yaml
+++ b/scripts/CEE/get-rhosak-operators/metadata.yaml
@@ -1,5 +1,5 @@
 file: get-rhosak-operators.sh
-name: get-RHOSAK-operators
+name: get-rhosak-operators
 description: |
   The get-rhosak-operators.sh script uses oc adm inspect to get a multitude of Production resources including; logs, events and managedKafkaAgents for the following namespaces:
     * managed-application-services-observability


### PR DESCRIPTION
`get-rhosak-operators` name in the metadata file does not mach the directory name. This causes a 404 error if you try to run or describe the script using the name provided by `backplane scripts list`.

```
$ ocm backplane script describe CEE/get-RHOSAK-operators
ERRO[0000] error from backplane: 
 Status Code: 404
 Message: Script not found
```