### PR TITLE
updating rbac cluster roles

### DIFF
--- a/scripts/CEE/get-kafka-instance-state/metadata.yaml
+++ b/scripts/CEE/get-kafka-instance-state/metadata.yaml
@@ -11,15 +11,6 @@ allowedGroups:
   - SREP
   - CSSRE
   - CEE
-rbac:
-  clusterRoleRules:
-    - verbs:
-        - "get"
-        - "list"
-      apiGroups:
-        - ""
-      resources:
-        - "secrets"
 envs:
   - key: "resource_namespace"
     description: "Namespace for the Kafka instance you want to query"

--- a/scripts/CEE/get-kafka-instance-state/metadata.yaml
+++ b/scripts/CEE/get-kafka-instance-state/metadata.yaml
@@ -14,64 +14,12 @@ allowedGroups:
 rbac:
   clusterRoleRules:
     - verbs:
-        - "adm"
-      apiGroups:
-        - ""
-      resources:
-        - "inspect"
-    - verbs:
-        - "create"
-      apiGroups:
-        - ""
-      resources:
-        - "pods/exec"
-    - verbs:
         - "get"
         - "list"
       apiGroups:
-        - "apps"
-      resources:
-        - "statefulsets"
-    - verbs:
-        - "get"
-      apiGroups:
         - ""
       resources:
-        - "pods"
-    - verbs:
-        - "list"
-      apiGroups:
-        - "managedkafka.bf2.org"
-      resources:
-        - "managedkafkas"
-    - verbs:
-        - "list"
-      apiGroups:
-        - "kafka.strimzi.io"
-      resources:
-        - "kafkas"
-    - verbs:
-        - "list"
-      apiGroups:
-        - "discovery.k8s.io"
-      resources:
-        - "endpointslice"
-  roles:
-    - namespace: "default"
-      rules:
-        - verbs:
-            - "get"
-            - "list"
-          apiGroups:
-            - ""
-          resources:
-            - "pods/exec"
-        - verbs:
-            - "create"
-          apiGroups:
-            - ""
-          resources:
-            - "pods/exec"
+        - "secrets"
 envs:
   - key: "resource_namespace"
     description: "Namespace for the Kafka instance you want to query"

--- a/scripts/CEE/get-rhosak-operators/metadata.yaml
+++ b/scripts/CEE/get-rhosak-operators/metadata.yaml
@@ -11,6 +11,15 @@ allowedGroups:
   - SREP
   - CSSRE
   - CEE
+rbac:
+  clusterRoleRules:
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - ""
+      resources:
+        - "secrets"  
 envs:
   - key: 'since'
     description: "The --since flag is used by the oc adm inspect command. Only return logs newer than a relative duration. Either since can be added or since_time can be added but not both."

--- a/scripts/CEE/get-rhosak-operators/metadata.yaml
+++ b/scripts/CEE/get-rhosak-operators/metadata.yaml
@@ -11,15 +11,6 @@ allowedGroups:
   - SREP
   - CSSRE
   - CEE
-rbac:
-  clusterRoleRules:
-    - verbs:
-        - "get"
-        - "list"
-      apiGroups:
-        - ""
-      resources:
-        - "secrets"  
 envs:
   - key: 'since'
     description: "The --since flag is used by the oc adm inspect command. Only return logs newer than a relative duration. Either since can be added or since_time can be added but not both."


### PR DESCRIPTION
fixing the rbac permissions in the get kafka instance script to remove rbac as the default cluster read permissions is enough  https://issues.redhat.com/browse/MGDSTRM-8074