### PR TITLE
List alerts for multiple Prometheus hosts

### DIFF
--- a/scripts/CEE/list-alerts/README.md
+++ b/scripts/CEE/list-alerts/README.md
@@ -47,13 +47,13 @@ ocm backplane managedjob create CEE/list-alerts
 ```
 
 #### Host Options
-The `NAMESPACES` environment variable which is a list of namespaces containing a Prometheus instance that you want to check the alerts in:
+The `NAMESPACES_TO_CHECK` environment variable which is a list of namespaces containing a Prometheus instance that you want to check the alerts in:
 ```bash
 # Checks Prometheus the application-services-observability namespace only
-ocm backplane managedjob create CEE/list-alerts -p NAMESPACES="application-services-observability"
+ocm backplane managedjob create CEE/list-alerts -p NAMESPACES_TO_CHECK="application-services-observability"
 
 # Checks Prometheus in the application-services-observability and user-observability namespaces
-ocm backplane managedjob create CEE/list-alerts -p NAMESPACES="application-services-observability user-observability"
+ocm backplane managedjob create CEE/list-alerts -p NAMESPACES_TO_CHECK="application-services-observability user-observability"
 
 # [Default] Checks the openshift-monitoring Prometheus instance only
 ocm backplane managedjob create CEE/list-alerts 

--- a/scripts/CEE/list-alerts/README.md
+++ b/scripts/CEE/list-alerts/README.md
@@ -2,13 +2,13 @@
 
 ## Purpose
 
-The script is used to ease liar on-going alerts and silence for a given cluster.
-It allows to filter by severity (warning or critical) and alert state (firing or pending).
-Pending alerts are for conditions which are currently triggered but for less than the configured threshold duration (and hence, did not alert yet). 
+The script is used to list ongoing alerts and silences for a given cluster.
+It allows filtering by severity (warning or critical) and alert state (firing or pending).
+Pending alerts are for conditions which are currently triggered but for less than the configured threshold duration (and hence, did not alert yet). It also provides the option to check alerts in one or more Prometheus instances by passing in a list of namespaces running Prometheus.
 
 ## Parameters and usage 
 ### Script usage
-
+#### Alert Options
 ```bash
 usage: script.sh [--warning-only|--critical-only] [--firing-only|--pending-only|--all-states] | --list-silences
 Default : Retrieved warning and critical alerts in Firing state
@@ -23,9 +23,17 @@ Default : Retrieved warning and critical alerts in Firing state
 `--firing-only` , `--pending-only` and `--all-states` are mutually exclusive. 
 The same way, `--warning-only` and `--critical-only` are mutually exclusive. 
 
-### Usage with managed-scripts
+#### Host Options
+```bash
+# Print out the namespace and host name of Prometheus instances on the cluster
+usage: script.sh --hosts
+```
 
-For usage with managed-scripts, the options need to be passed through the `SCRIPT_PARAMETERS` environment variable. Here are some examples : 
+### Usage with managed-scripts
+For usage with managed-scripts, there are two options that can be passed through as environment variables. Each option can be used individually or together:
+
+#### Alert Options
+The `SCRIPT_PARAMETERS` environment variable which is a list of alert options:
 
 ```bash
 ocm backplane managedjob create CEE/list-alerts -p SCRIPT_PARAMETERS="--warning-only --pending-only"
@@ -34,6 +42,19 @@ ocm backplane managedjob create CEE/list-alerts -p SCRIPT_PARAMETERS="--all-stat
 
 ocm backplane managedjob create CEE/list-alerts -p SCRIPT_PARAMETERS="--list-silences"
 
-# This will list all the firing alerts (warning and critical)
+# [Default] This will list all the firing alerts (warning and critical)
+ocm backplane managedjob create CEE/list-alerts 
+```
+
+#### Host Options
+The `NAMESPACES` environment variable which is a list of namespaces containing a Prometheus instance that you want to check the alerts in:
+```bash
+# Checks Prometheus the application-services-observability namespace only
+ocm backplane managedjob create CEE/list-alerts -p NAMESPACES="application-services-observability"
+
+# Checks Prometheus in the application-services-observability and user-observability namespaces
+ocm backplane managedjob create CEE/list-alerts -p NAMESPACES="application-services-observability user-observability"
+
+# [Default] Checks the openshift-monitoring Prometheus instance only
 ocm backplane managedjob create CEE/list-alerts 
 ```

--- a/scripts/CEE/list-alerts/script.sh
+++ b/scripts/CEE/list-alerts/script.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 # default is retrieved all firing alerts (critical+warning)
 IS_CRITICAL=1
@@ -17,12 +18,12 @@ function list_prometheus_hosts(){
 function check_namespace_exists(){
 
     # Read in the list of namespaces from the command line argument
-    read -a PROMETHEUS_HOSTS_ARRAY <<< "$NAMESPACES"
+    read -r -a PROMETHEUS_HOSTS_ARRAY <<< "$NAMESPACES_TO_CHECK"
 
 # If a namespace in the list doesn't exist, remove it
 for NAMESPACE in "${PROMETHEUS_HOSTS_ARRAY[@]}" ; do
 	if [[ $(oc get project "${NAMESPACE}" --no-headers) == "" ]]; then
-		unset PROMETHEUS_HOSTS_ARRAY[$NAMESPACE]
+		unset "PROMETHEUS_HOSTS_ARRAY[$NAMESPACE]"
 	fi
 done
 }
@@ -98,7 +99,7 @@ function list_alerts(){
 	fi
 
     # If the array is not empty, loop through the list and retrieve the Prometheus route from the supplied namespaces
-    if [[ -n "${PROMETHEUS_HOSTS_ARRAY[@]}" ]]
+    if (( ${#PROMETHEUS_HOSTS_ARRAY[@]} ))
     then
 	    for NAMESPACE in "${PROMETHEUS_HOSTS_ARRAY[@]}" ; do
 		    while read -r a b; do declare -A hostarray["$a"]="$b"; done < <(oc get routes -n "${NAMESPACE}" -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name | grep prometheus)

--- a/scripts/CEE/list-alerts/script.sh
+++ b/scripts/CEE/list-alerts/script.sh
@@ -6,8 +6,6 @@ IS_WARNING=1
 PRINT_SILENCE=0
 NAMESPACE_QUERY="namespace=~\"^$|^default$|^openshift-.*|^kube-.*|^redhat-.*\",namespace!~\"^redhat-rhmi-.*\""
 ALERTSTATE_QUERY="alertstate=\"firing\","
-
-# Declare an associative array to hold the namespace and prometheus host names
 declare -A hostarray
 
 # Lists Prometheus hosts on the cluster if the --hosts argument is passed
@@ -16,95 +14,104 @@ function list_prometheus_hosts(){
 	exit 1
 }
 
-# Checks of the --hosts parameter was provided
-[[ ${1} == "--hosts" ]] && list_prometheus_hosts
+# Check if the namespaces provided exist
+function check_namespace_exists(){
+	PROMETHEUS_HOSTS_ARRAY=("$NAMESPACES")
 
-# List of namespaces containing prometheus instances
-PROMETHEUS_HOSTS_ARRAY=($NAMESPACES)
-
-# List of array options
-ALERT_OPTIONS_ARRAY=($SCRIPT_PARAMETERS)
-
-for ARG in "${ALERT_OPTIONS_ARRAY[@]}" ; do
-	if [ "$ARG" == "--warning-only" ] ; then
-		IS_CRITICAL=0
-		IS_WARNING_ONLY=1
-	elif [ "$ARG" == "--critical-only" ] ; then
-		IS_WARNING=0
-		IS_CRITICAL_ONLY=1
-	elif [ "$ARG" == "--pending-only" ] ; then
-		ALERTSTATE_QUERY="alertstate=\"pending\","
-		IS_PENDING_ONLY=1
-	elif [ "$ARG" == "--firing-only" ] ; then
-		ALERTSTATE_QUERY="alertstate=\"firing\","
-		IS_FIRING_ONLY=1
-	elif [ "$ARG" == "--all-states" ] ; then
-		ALERTSTATE_QUERY=""
-		NAMESPACE_QUERY=""
-		IS_ALL_STATES=1
-	elif [ "$ARG" == "--list-silences" ] ; then
-		PRINT_SILENCE=1
-	else
-		echo "usage: script.sh [--warning-only|--critical-only] [--firing-only|--pending-only|--all-states]"
-		echo "  --warning-only: print warning alerts only"
-		echo "  --critical-only: print critical alerts only"
-		echo "  --firing-only: print only firing alert state (default)"
-		echo "  --pending-only: print only pending alert state"
-		echo "  --all-states: print firing and pending alerts"
-		echo "  --list-silences: print all active silences"
-		exit 1
+# If a namespace in the list doesn't exist, remove it
+for NAMESPACE in "${PROMETHEUS_HOSTS_ARRAY[@]}" ; do
+	if [[ $(oc get project "${NAMESPACE}" --no-headers) == "" ]]; then
+		unset PROMETHEUS_HOSTS_ARRAY[$NAMESPACE]
 	fi
 done
+}
+
+# Sets the types of alerts to retrieve (warning, critical, firing-only, pending, all-states)
+function set_alert_list(){
+	# List of alert states
+	ALERT_OPTIONS_ARRAY=($SCRIPT_PARAMETERS)
+
+	for ARG in "${ALERT_OPTIONS_ARRAY[@]}" ; do
+		if [ "$ARG" == "--warning-only" ] ; then
+			IS_CRITICAL=0
+			IS_WARNING_ONLY=1
+		elif [ "$ARG" == "--critical-only" ] ; then
+			IS_WARNING=0
+			IS_CRITICAL_ONLY=1
+		elif [ "$ARG" == "--pending-only" ] ; then
+			ALERTSTATE_QUERY="alertstate=\"pending\","
+			IS_PENDING_ONLY=1
+		elif [ "$ARG" == "--firing-only" ] ; then
+			ALERTSTATE_QUERY="alertstate=\"firing\","
+			IS_FIRING_ONLY=1
+		elif [ "$ARG" == "--all-states" ] ; then
+			ALERTSTATE_QUERY=""
+			NAMESPACE_QUERY=""
+			IS_ALL_STATES=1
+		elif [ "$ARG" == "--list-silences" ] ; then
+			PRINT_SILENCE=1
+		else
+			echo "usage: script.sh [--warning-only|--critical-only] [--firing-only|--pending-only|--all-states]"
+			echo "  --warning-only: print warning alerts only"
+			echo "  --critical-only: print critical alerts only"
+			echo "  --firing-only: print only firing alert state (default)"
+			echo "  --pending-only: print only pending alert state"
+			echo "  --all-states: print firing and pending alerts"
+			echo "  --list-silences: print all active silences"
+			exit 1
+		fi
+	done
+}
 
 function _get_host {
 	oc -n "$1" get routes "$2" -o json | jq -r .spec.host
 }
 
-if [[ $((IS_FIRING_ONLY+IS_PENDING_ONLY+IS_ALL_STATES)) -gt 1 ]] ; then
-	echo "--pending-only, --firing-only and --all are mutually exclusive."
-	exit 2
-fi
+function list_alerts(){
+	if [[ $((IS_FIRING_ONLY+IS_PENDING_ONLY+IS_ALL_STATES)) -gt 1 ]] ; then
+		echo "--pending-only, --firing-only and --all are mutually exclusive."
+		exit 2
+	fi
 
-if [[ $((IS_WARNING_ONLY+IS_CRITICAL_ONLY)) -gt 1 ]] ; then
-	echo "--warning-only and --critical-only are mutually exclusive."
-	exit 2
-fi
+	if [[ $((IS_WARNING_ONLY+IS_CRITICAL_ONLY)) -gt 1 ]] ; then
+		echo "--warning-only and --critical-only are mutually exclusive."
+		exit 2
+	fi
 
-if [[ $IS_ALL_STATES == 1 ]] ; then
-	echo "Retrieving pending and firing alerts"
-elif [[ $IS_PENDING_ONLY == 1 ]] ; then
-	echo "Retrieving only pending alerts"
-else
-	#Default is to retrieve only firing alerts
-	echo "Retrieving only firing alerts"
-fi
-
-if [[ $IS_CRITICAL_ONLY -eq 1 ]] ; then
-	echo "Retrieving only Critical alerts"
-elif [[ $IS_WARNING_ONLY -eq 1 ]] ; then
-	echo "Retrieving only Warning alerts"
-else
-	#Default is to retrieve both Critical and Warning alerts
-	echo "Retrieving both Critical and Warning alerts"
-fi
-
-if [ -n "$PROMETHEUS_HOSTS_ARRAY" ]
-then
-	for NAMESPACE in "${PROMETHEUS_HOSTS_ARRAY[@]}" ; do
-
-		while read -r a b; do declare -A hostarray["$a"]="$b"; done < <(oc get routes -n ${NAMESPACE} -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name | grep prometheus)
-		done
+	if [[ $IS_ALL_STATES == 1 ]] ; then
+		echo "Retrieving pending and firing alerts"
+	elif [[ $IS_PENDING_ONLY == 1 ]] ; then
+		echo "Retrieving only pending alerts"
 	else
-		# If the array is empty, use the default host (openshift-monitoring prometheus-k8s)
-		hostarray[openshift-monitoring]=prometheus-k8s
-fi
+		#Default is to retrieve only firing alerts
+		echo "Retrieving only firing alerts"
+	fi
 
-for host in "${!hostarray[@]}" ; do
-	echo "Retrieving alerts from the ${hostarray[$host]} Prometheus instance in the ${host} namespace:"
-	PROM_HOST=$(_get_host ${host} ${hostarray[$host]})
-	PROM_TOKEN=$(oc -n ${host} sa get-token ${hostarray[$host]})
-	# The alertmanager route name differs for each namespace, so we need to retrieve it dynamically
-	AM_HOST=$(_get_host "${host}" $(oc get routes -n ${host} -o custom-columns=NAME:.metadata.name | grep alertmanager))
+	if [[ $IS_CRITICAL_ONLY -eq 1 ]] ; then
+		echo "Retrieving only Critical alerts"
+	elif [[ $IS_WARNING_ONLY -eq 1 ]] ; then
+		echo "Retrieving only Warning alerts"
+	else
+		#Default is to retrieve both Critical and Warning alerts
+		echo "Retrieving both Critical and Warning alerts"
+	fi
+
+	if [ -n "${PROMETHEUS_HOSTS_ARRAY[@]}" ]
+	then
+		for NAMESPACE in "${PROMETHEUS_HOSTS_ARRAY[@]}" ; do
+			while read -r a b; do declare -A hostarray["$a"]="$b"; done < <(oc get routes -n "${NAMESPACE}" -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name | grep prometheus)
+			done
+		else
+			# If the array is empty, use the default namespace and host (openshift-monitoring prometheus-k8s)
+			hostarray[openshift-monitoring]=prometheus-k8s
+	fi
+
+	for host in "${!hostarray[@]}" ; do
+		echo "Retrieving alerts from the ${hostarray[$host]} Prometheus instance in the ${host} namespace:"
+		PROM_HOST=$(_get_host ${host} ${hostarray[$host]})
+		PROM_TOKEN=$(oc -n ${host} sa get-token ${hostarray[$host]})
+		# The alertmanager route name differs for each namespace, so we need to retrieve it dynamically
+		AM_HOST=$(_get_host "${host}" "$(oc get routes -n ${host} -o custom-columns=NAME:.metadata.name | grep alertmanager)")
 
 # Only set these if we need them
 if [[ $((IS_CRITICAL+IS_WARNING)) -gt 0 ]] ; then
@@ -141,5 +148,12 @@ if [ $PRINT_SILENCE == 1 ] ; then
 		echo "$ALL_SILENCES" | jq -r .
 	fi
 fi
-
 done
+}
+
+# Check if the --hosts parameter was provided
+[[ ${1} == "--hosts" ]] && list_prometheus_hosts
+
+check_namespace_exists
+set_alert_list
+list_alerts

--- a/scripts/CEE/list-alerts/script.sh
+++ b/scripts/CEE/list-alerts/script.sh
@@ -1,114 +1,145 @@
 #!/bin/bash
 
-# default is retrived all firing alerts (critical+warning)
+# default is retrieved all firing alerts (critical+warning)
 IS_CRITICAL=1
 IS_WARNING=1
 PRINT_SILENCE=0
 NAMESPACE_QUERY="namespace=~\"^$|^default$|^openshift-.*|^kube-.*|^redhat-.*\",namespace!~\"^redhat-rhmi-.*\""
 ALERTSTATE_QUERY="alertstate=\"firing\","
 
-ARG_ARRAY=( $SCRIPT_PARAMETERS )
+# Declare an associative array to hold the namespace and prometheus host names
+declare -A hostarray
 
-for ARG in "${ARG_ARRAY[@]}" ; do
-    if [ "$ARG" == "--warning-only" ] ; then
-        IS_CRITICAL=0
-        IS_WARNING_ONLY=1
-    elif [ "$ARG" == "--critical-only" ] ; then
-        IS_WARNING=0
-        IS_CRITICAL_ONLY=1
-    elif [ "$ARG" == "--pending-only" ] ; then
-        ALERTSTATE_QUERY="alertstate=\"pending\","
-        IS_PENDING_ONLY=1
-    elif [ "$ARG" == "--firing-only" ] ; then
-        ALERTSTATE_QUERY="alertstate=\"firing\","
-        IS_FIRING_ONLY=1
-    elif [ "$ARG" == "--all-states" ] ; then
-        ALERTSTATE_QUERY=""
-        NAMESPACE_QUERY=""
-        IS_ALL_STATES=1
-    elif [ "$ARG" == "--list-silences" ] ; then
-        PRINT_SILENCE=1
-    else
-        echo "usage: script.sh [--warning-only|--critical-only] [--firing-only|--pending-only|--all-states]"
-        echo "  --warning-only: print warning alerts only"
-        echo "  --critical-only: print critical alerts only"
-        echo "  --firing-only: print only firing alert state (default)"
-        echo "  --pending-only: print only pending alert state"
-        echo "  --all-states: print firing and pending alerts"
-        echo "  --list-silences: print all active silences"
-        exit 1
-    fi
+# Lists Prometheus hosts on the cluster if the --hosts argument is passed
+function list_prometheus_hosts(){
+	eval "oc get routes --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name | grep prometheus"
+	exit 1
+}
+
+# Checks of the --hosts parameter was provided
+[[ ${1} == "--hosts" ]] && list_prometheus_hosts
+
+# List of namespaces containing prometheus instances
+PROMETHEUS_HOSTS_ARRAY=($NAMESPACES)
+
+# List of array options
+ALERT_OPTIONS_ARRAY=($SCRIPT_PARAMETERS)
+
+for ARG in "${ALERT_OPTIONS_ARRAY[@]}" ; do
+	if [ "$ARG" == "--warning-only" ] ; then
+		IS_CRITICAL=0
+		IS_WARNING_ONLY=1
+	elif [ "$ARG" == "--critical-only" ] ; then
+		IS_WARNING=0
+		IS_CRITICAL_ONLY=1
+	elif [ "$ARG" == "--pending-only" ] ; then
+		ALERTSTATE_QUERY="alertstate=\"pending\","
+		IS_PENDING_ONLY=1
+	elif [ "$ARG" == "--firing-only" ] ; then
+		ALERTSTATE_QUERY="alertstate=\"firing\","
+		IS_FIRING_ONLY=1
+	elif [ "$ARG" == "--all-states" ] ; then
+		ALERTSTATE_QUERY=""
+		NAMESPACE_QUERY=""
+		IS_ALL_STATES=1
+	elif [ "$ARG" == "--list-silences" ] ; then
+		PRINT_SILENCE=1
+	else
+		echo "usage: script.sh [--warning-only|--critical-only] [--firing-only|--pending-only|--all-states]"
+		echo "  --warning-only: print warning alerts only"
+		echo "  --critical-only: print critical alerts only"
+		echo "  --firing-only: print only firing alert state (default)"
+		echo "  --pending-only: print only pending alert state"
+		echo "  --all-states: print firing and pending alerts"
+		echo "  --list-silences: print all active silences"
+		exit 1
+	fi
 done
 
 function _get_host {
-    oc -n openshift-monitoring get routes "$1" -o json | jq -r .spec.host
+	oc -n "$1" get routes "$2" -o json | jq -r .spec.host
 }
 
 if [[ $((IS_FIRING_ONLY+IS_PENDING_ONLY+IS_ALL_STATES)) -gt 1 ]] ; then
-    echo "--pending-only, --firing-only and --all are mutually exclusive."
-    exit 2
+	echo "--pending-only, --firing-only and --all are mutually exclusive."
+	exit 2
 fi
 
 if [[ $((IS_WARNING_ONLY+IS_CRITICAL_ONLY)) -gt 1 ]] ; then
-    echo "--warning-only and --critical-only are mutually exclusive."
-    exit 2
+	echo "--warning-only and --critical-only are mutually exclusive."
+	exit 2
 fi
 
 if [[ $IS_ALL_STATES == 1 ]] ; then
-    echo "Retrieving pending and firing alerts"
+	echo "Retrieving pending and firing alerts"
 elif [[ $IS_PENDING_ONLY == 1 ]] ; then
-    echo "Retrieving only pending alerts"
+	echo "Retrieving only pending alerts"
 else
-    #Default is to retrieve only firing alerts
-    echo "Retrieving only firing alerts"
+	#Default is to retrieve only firing alerts
+	echo "Retrieving only firing alerts"
 fi
 
 if [[ $IS_CRITICAL_ONLY -eq 1 ]] ; then
-    echo "Retrieving only Critical alerts"
+	echo "Retrieving only Critical alerts"
 elif [[ $IS_WARNING_ONLY -eq 1 ]] ; then
-    echo "Retrieving only Warning alerts"
+	echo "Retrieving only Warning alerts"
 else
-    #Default is to retrieve both Critical and Warning alerts
-    echo "Retrieving both Critical and Warning alerts"
+	#Default is to retrieve both Critical and Warning alerts
+	echo "Retrieving both Critical and Warning alerts"
 fi
 
-PROM_HOST=$(_get_host prometheus-k8s)
-PROM_TOKEN=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
-AM_HOST=$(_get_host alertmanager-main)
+if [ -n "$PROMETHEUS_HOSTS_ARRAY" ]
+then
+	for NAMESPACE in "${PROMETHEUS_HOSTS_ARRAY[@]}" ; do
+
+		while read -r a b; do declare -A hostarray["$a"]="$b"; done < <(oc get routes -n ${NAMESPACE} -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name | grep prometheus)
+		done
+	else
+		# If the array is empty, use the default host (openshift-monitoring prometheus-k8s)
+		hostarray[openshift-monitoring]=prometheus-k8s
+fi
+
+for host in "${!hostarray[@]}" ; do
+	echo "Retrieving alerts from the ${hostarray[$host]} Prometheus instance in the ${host} namespace:"
+	PROM_HOST=$(_get_host ${host} ${hostarray[$host]})
+	PROM_TOKEN=$(oc -n ${host} sa get-token ${hostarray[$host]})
+	# The alertmanager route name differs for each namespace, so we need to retrieve it dynamically
+	AM_HOST=$(_get_host "${host}" $(oc get routes -n ${host} -o custom-columns=NAME:.metadata.name | grep alertmanager))
 
 # Only set these if we need them
 if [[ $((IS_CRITICAL+IS_WARNING)) -gt 0 ]] ; then
-    ALL_ALERTS=$(curl -G -s -k -H "Authorization: Bearer $PROM_TOKEN" --data-urlencode "query=ALERTS{${ALERTSTATE_QUERY}${NAMESPACE_QUERY}}" "https://$PROM_HOST/api/v1/query")
-    COUNT_CRITICAL=$(echo "$ALL_ALERTS" | jq -r '.data.result[].metric | select(.severity == "critical") | .alertname' | wc -l)
-    COUNT_WARNING=$(echo "$ALL_ALERTS" | jq -r '.data.result[].metric | select(.severity == "warning") | select(.alertname != "UsingDeprecatedAPIExtensionsV1Beta1") | select(.alertname != "UsingDeprecatedAPIAppsV1Beta2") | select(.alertname != "UsingDeprecatedAPIAppsV1Beta1") | .alertname' | wc -l)
+	ALL_ALERTS=$(curl -G -s -k -H "Authorization: Bearer $PROM_TOKEN" --data-urlencode "query=ALERTS{${ALERTSTATE_QUERY}${NAMESPACE_QUERY}}" "https://$PROM_HOST/api/v1/query")
+	COUNT_CRITICAL=$(echo "$ALL_ALERTS" | jq -r '.data.result[].metric | select(.severity == "critical") | .alertname' | wc -l)
+	COUNT_WARNING=$(echo "$ALL_ALERTS" | jq -r '.data.result[].metric | select(.severity == "warning") | select(.alertname != "UsingDeprecatedAPIExtensionsV1Beta1") | select(.alertname != "UsingDeprecatedAPIAppsV1Beta2") | select(.alertname != "UsingDeprecatedAPIAppsV1Beta1") | .alertname' | wc -l)
 fi
 
 if [ $IS_CRITICAL == 1 ] ; then
-    echo "Critical Alerts:"
-    if [ "$COUNT_CRITICAL" = "0" ] ; then
-        echo "{}"
-    else
-        echo "$ALL_ALERTS" | jq -r '.data.result[].metric | select(.severity == "critical") | {alertname, job, namespace, exported_namespace, pod, service, alertstate}'
-    fi
+	echo "Critical Alerts:"
+	if [ "$COUNT_CRITICAL" = "0" ] ; then
+		echo "{}"
+	else
+		echo "$ALL_ALERTS" | jq -r '.data.result[].metric | select(.severity == "critical") | {alertname, job, namespace, exported_namespace, pod, service, alertstate}'
+	fi
 fi
 
 if [ $IS_WARNING == 1 ] ; then
-    echo "Warning Alerts:"
-    if [ "$COUNT_WARNING" = "0" ] ; then
-        echo "{}"
-    else
-        echo "$ALL_ALERTS" | jq -r '.data.result[].metric | select(.severity == "warning") | select(.alertname != "UsingDeprecatedAPIExtensionsV1Beta1") | select(.alertname != "UsingDeprecatedAPIAppsV1Beta2") | select(.alertname != "UsingDeprecatedAPIAppsV1Beta1") | {alertname, job, namespace, exported_namespace, pod, service, alertstate}'
-    fi
+	echo "Warning Alerts:"
+	if [ "$COUNT_WARNING" = "0" ] ; then
+		echo "{}"
+	else
+		echo "$ALL_ALERTS" | jq -r '.data.result[].metric | select(.severity == "warning") | select(.alertname != "UsingDeprecatedAPIExtensionsV1Beta1") | select(.alertname != "UsingDeprecatedAPIAppsV1Beta2") | select(.alertname != "UsingDeprecatedAPIAppsV1Beta1") | {alertname, job, namespace, exported_namespace, pod, service, alertstate}'
+	fi
 fi
 
 # Only set this if we need it
 if [ $PRINT_SILENCE == 1 ] ; then
-    ALL_SILENCES=$(curl -s -k -H "Authorization: Bearer $PROM_TOKEN"  "https://$AM_HOST/api/v1/silences" | jq -r '.data[] | select(.status.state == "active")')
-    echo "Silences:"
-    if [ -z "$ALL_SILENCES" ] ; then
-        echo " - None"
-    else
-        echo "$ALL_SILENCES" | jq -r .
-    fi
+	ALL_SILENCES=$(curl -s -k -H "Authorization: Bearer $PROM_TOKEN"  "https://$AM_HOST/api/v1/silences" | jq -r '.data[] | select(.status.state == "active")')
+	echo "Silences:"
+	if [ -z "$ALL_SILENCES" ] ; then
+		echo " - None"
+	else
+		echo "$ALL_SILENCES" | jq -r .
+	fi
 fi
 
+done


### PR DESCRIPTION
[MGDSTRM-8276](https://issues.redhat.com/browse/MGDSTRM-8276)

Update the script to list alerts from any/all Prometheus hosts by providing the namespace/s containing the Prometheus host. Defaults to checking the `openshift-monitoring` Prometheus if no namespace(s) are provided. The README contains instructions on how to use the script. It can tested when logged in via `oc` by exporting the `NAMESPACE` list: `export NAMESPACE="<list of namespaces>"`.