### PR TITLE
Added managed script for under min isr partitions

### DIFF
--- a/scripts/CSSRE/lib/py/kafka.py
+++ b/scripts/CSSRE/lib/py/kafka.py
@@ -16,7 +16,7 @@ class Kafka:
       return self._oc
 
 
-  def check_namepace_managed_kafka(self, namespace):
+  def check_namespace_managed_kafka(self, namespace):
     """
     Checks if a given namespace is a managed Kafka namespace, throws an error if it's not.
 

--- a/scripts/CSSRE/under-min-isr-partitions/README.md
+++ b/scripts/CSSRE/under-min-isr-partitions/README.md
@@ -1,0 +1,27 @@
+# Under Min ISR Partitions
+
+This script is intended to be used when the `UnderMinIsrPartitionCount` alert fires. The script uses the `kafka-topics.sh` script built into the Kafka brokers to determine which brokers are not in-sync and if they can be safely restarted and prints out this information.
+
+## Usage
+Parameters should be provided as environmental variables.
+
+## Running locally
+```bash
+KAFKA_NAMESPACE=<KAFKA_NAMESPACE> python under-min-isr-partitions.py
+
+# Examples
+KAFKA_NAMESPACE=my-kafka python under-min-isr-partitions.py
+KAFKA_NAMESPACE=my-kafka python under-min-isr-partitions.py --log-level=debug
+
+```
+
+## Running as a managed-script
+
+
+```bash
+ocm backplane managedjob create CSSRE/under-min-isr-partitions -p kafka_namespace=<KAFKA_NAMESPACE> [LOG_LEVEL=<LOG_LEVEL>]
+
+# Examples
+ocm backplane managedjob create CSSRE/under-min-isr-partitions -p KAFKA_NAMESPACE=<KAFKA_NAMESPACE>
+ocm backplane managedjob create CSSRE/under-min-isr-partitions -p KAFKA_NAMESPACE=<KAFKA_NAMESPACE> -p LOG_LEVEL=debug
+```

--- a/scripts/CSSRE/under-min-isr-partitions/metadata.yaml
+++ b/scripts/CSSRE/under-min-isr-partitions/metadata.yaml
@@ -1,0 +1,42 @@
+file: under-min-isr-partitions.py
+name: under-min-isr-partitions
+description: |
+  Debug partitions under minimum in-sync replica alert on a cluster and instruct which brokers should and can be restarted.
+author: Rob Shelly
+allowedGroups:
+  - CSSRE
+rbac:
+  clusterRoleRules:
+    - verbs:
+        - "create"
+      apiGroups:
+        - ""
+      resources:
+        - "pods/exec"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "apps"
+      resources:
+        - "statefulsets"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - ""
+      resources:
+        - "pods"
+    - verbs:
+        - "list"
+      apiGroups:
+        - "kafka.strimzi.io"
+      resources:
+        - "kafkas"
+envs:
+  - key: "KAFKA_NAMESPACE"
+    description: "Namespace for the Kafka instance you want to query"
+    optional: false
+  - key: "LOG_LEVEL"
+    optional: true
+language: python

--- a/scripts/CSSRE/under-min-isr-partitions/under-min-isr-partitions.py
+++ b/scripts/CSSRE/under-min-isr-partitions/under-min-isr-partitions.py
@@ -1,0 +1,57 @@
+import argparse
+import sys
+
+LIB_PATH = "/managed-scripts/CSSRE/lib"
+# Use sys.path.insert because PYTHONPATH's support is unclear
+sys.path.insert(0, LIB_PATH)
+
+from py.script import Script
+from py.kafka import Kafka
+
+class UnderMinIsrPartitions(Script):
+  def __init__(self):
+    super().__init__(logger_name="Under Min ISR Partitions", env_vars=["KAFKA_NAMESPACE"], check_env_var=False)
+
+  def create_parser(self):
+    self.parser = argparse.ArgumentParser(description="Checks for Kafka under min ISR partitions.")
+    self.parser.add_argument("--kafka-namespace", help="The namespace of the kafka")
+    self.parser.add_argument("--log-level", help="Set logging level.")
+
+  def run(self):
+    self.logger.debug("---Running managed script: Under Min ISR Partitions---")
+
+    kafka = Kafka(self.oc, self.settings, logger_name="Under Min ISR Partitions")
+    kafka.check_namepace_managed_kafka(self.KAFKA_NAMESPACE)
+    cluster = kafka.get_kafka_cluster(self.KAFKA_NAMESPACE)
+    
+    if cluster is None:
+      self.exit(
+        self.logger.error("No kafka found in namespace %s" % self.KAFKA_NAMESPACE)
+      )
+    self.logger.info("Found Kafka %s in namespace %s" % (cluster.name(), self.KAFKA_NAMESPACE))
+
+    num_pods_ready, num_pods = kafka.check_all_brokers_active(self.KAFKA_NAMESPACE)
+    if num_pods_ready < num_pods:
+      self.exit(
+        self.logger.info(
+          '''There are pods in a not ready state.
+          This is the most likely cause of under min ISR partitions and this script will not be able to resolve the under replicated partitions while there are pods in a not ready state.
+          Kafka pods ready: %d/%d''' % (num_pods_ready, num_pods))
+      )
+
+    topics = kafka.run_kafka_topics_script(self.KAFKA_NAMESPACE, cluster.name(), filter="under-min-isr-partitions")
+    if topics.out().count('Partition') == 0:
+      self.exit(
+        self.logger.info("There are no under min ISR partitions")
+      )
+      
+    self.logger.info("There are %d under min ISR partitions:\n%s" % (topics.out().count('Partition'), topics.out()))
+
+    out_of_sync_brokers = kafka.get_out_of_sync_brokers(topics.out())
+    self.logger.info("The following brokers should be restarted: %s" % out_of_sync_brokers)
+
+    safe_to_restart_brokers = kafka.check_broker_safe_restart(self.KAFKA_NAMESPACE, cluster, topics, out_of_sync_brokers)
+    self.logger.info("The following brokers can be safely restarted %s" % safe_to_restart_brokers)
+
+if __name__ == "__main__":
+  UnderMinIsrPartitions()

--- a/scripts/CSSRE/under-min-isr-partitions/under-min-isr-partitions.py
+++ b/scripts/CSSRE/under-min-isr-partitions/under-min-isr-partitions.py
@@ -21,7 +21,7 @@ class UnderMinIsrPartitions(Script):
     self.logger.debug("---Running managed script: Under Min ISR Partitions---")
 
     kafka = Kafka(self.oc, self.settings, logger_name="Under Min ISR Partitions")
-    kafka.check_namepace_managed_kafka(self.KAFKA_NAMESPACE)
+    kafka.check_namespace_managed_kafka(self.KAFKA_NAMESPACE)
     cluster = kafka.get_kafka_cluster(self.KAFKA_NAMESPACE)
     
     if cluster is None:

--- a/scripts/CSSRE/under-replicated-partitions/under-replicated-partitions.py
+++ b/scripts/CSSRE/under-replicated-partitions/under-replicated-partitions.py
@@ -21,7 +21,7 @@ class UnderReplicatedPartitions(Script):
     self.logger.debug("---Running managed script: Under Replicated Partitions---")
 
     kafka = Kafka(self.oc, self.settings, logger_name="Under Replicated Partitions")
-    kafka.check_namepace_managed_kafka(self.KAFKA_NAMESPACE)
+    kafka.check_namespace_managed_kafka(self.KAFKA_NAMESPACE)
     cluster = kafka.get_kafka_cluster(self.KAFKA_NAMESPACE)
     
     if cluster is None:


### PR DESCRIPTION
This is a managed script for the under min ISR alert in Kafka. It's pretty much a copy paste of the [under replicated partition managed script](https://github.com/openshift/managed-scripts/tree/main/scripts/CSSRE/under-replicated-partitions) as the kafka.py class already has the logic to handle partitions that are under minimum ISR. 