### PR TITLE
Fix clustersync-breaking bug in delete-olm-operator

### DIFF
--- a/scripts/SREP/delete-olm-operator/script.sh
+++ b/scripts/SREP/delete-olm-operator/script.sh
@@ -19,11 +19,11 @@ fi
 
 "$DELETE" || echo "Not going to delete resources"
 
-SUBSCRIPTION_SAVED=$(oc get subscriptions.operators.coreos.com -n "${NAMESPACE}" -oyaml)
+SUBSCRIPTION_SAVED=$(oc get subscriptions.operators.coreos.com -n "${NAMESPACE}" -ojson | jq -r 'del(.items[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration")')
 SUBSCRIPTION=$(oc get subscriptions.operators.coreos.com -n "${NAMESPACE}" -o jsonpath='{.items[*].metadata.name}')
-CATALOG_SOURCE_SAVED=$(oc get catalogsources.operators.coreos.com -n "${NAMESPACE}" -oyaml)
+CATALOG_SOURCE_SAVED=$(oc get catalogsources.operators.coreos.com -n "${NAMESPACE}" -ojson | jq -r 'del(.items[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration")')
 CATALOG_SOURCE=$(oc get catalogsources.operators.coreos.com -n "${NAMESPACE}" -o jsonpath='{.items[*].metadata.name}')
-OPERATOR_GROUP_SAVED=$(oc get operatorgroups.operators.coreos.com -n "${NAMESPACE}" -oyaml)
+OPERATOR_GROUP_SAVED=$(oc get operatorgroups.operators.coreos.com -n "${NAMESPACE}" -ojson | jq -r 'del(.items[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration")')
 OPERATOR_GROUP=$(oc get operatorgroups.operators.coreos.com -n "${NAMESPACE}" -o jsonpath='{.items[*].metadata.name}')
 
 


### PR DESCRIPTION
This corrects a bug in the `delete-olm-operator` managed script.

Currently this script does not remove the `last-applied-configuration` annotation from the `subscription`, `catalogsource` and `operatorgroup` resources that it saves, deletes and recreates.

This means that when the script recreates the resources, the Hive `clustersync` will no longer be able to successfully clustersync them. In the case of a `catalogsource` this is quite bad as it means the cluster will no longer be receiving operator updates.

The fix ensures that the `last-applied-configuration` annotation is removed.

I have tested it in a staging cluster to ensure it still works.