### PR TITLE
Fix resource name typo

### DIFF
--- a/scripts/CEE/pcap-collector/metadata.yaml
+++ b/scripts/CEE/pcap-collector/metadata.yaml
@@ -49,7 +49,7 @@ rbac:
       apiGroups:
         - "config.openshift.io"
       resources:
-        - "network"        
+        - "networks"        
 envs:
   - key: "NODE"
     description: "The node name"


### PR DESCRIPTION
_Error_ 
```
sh-4.4# oc get network cluster -o jsonpath='{.spec.networkType}'
Error from server (Forbidden): networks.config.openshift.io "cluster" is forbidden: User "system:serviceaccount:openshift-backplane-managed-scripts:openshift-job-r2krl" cannot get resource "networks" in API group "config.openshift.io" at the cluster scope
```

- This PR will fix the resource name typo 
