### PR TITLE
Change oc exec commands to use services instead of statefulsets

### DIFF
--- a/scripts/CEE/describe-kafka-transaction/describe-kafka-transaction.sh
+++ b/scripts/CEE/describe-kafka-transaction/describe-kafka-transaction.sh
@@ -3,10 +3,10 @@ set -o pipefail
 set -o nounset
 
 function main() {
-    local kafkaStatefulSet
-    kafkaStatefulSet=$(oc -n "${resource_namespace}" get statefulset -l app.kubernetes.io/name=kafka -o name)
-
-    oc exec -n "${resource_namespace}" "${kafkaStatefulSet}" -c kafka -- \
+    local service
+    service=$(oc -n "${resource_namespace}" get service  -o name -l "app.kubernetes.io/name=kafka" | grep bootstrap | head -n1)
+    
+    oc exec -n "${resource_namespace}" "${service}" -c kafka -- \
        ./bin/kafka-transactions.sh --bootstrap-server localhost:9096 describe --transactional-id "${transactional_id}"
 }
 

--- a/scripts/CEE/get-kafka-instance-state/get-kafka-instance-state.sh
+++ b/scripts/CEE/get-kafka-instance-state/get-kafka-instance-state.sh
@@ -20,8 +20,8 @@ function main() {
   managedKafkaCR=$(oc -n "${resource_namespace}" get managedkafka -o name)
   local kafkaCR
   kafkaCR=$(oc -n "${resource_namespace}" get kafka -o name)
-  local kafkaStatefulSet
-  kafkaStatefulSet=$(oc -n "${resource_namespace}" get statefulset -l app.kubernetes.io/name=kafka -o name)
+  local service
+  service=$(oc -n "${resource_namespace}" get service  -o name -l "app.kubernetes.io/name=kafka" | grep bootstrap | head -n1)
 
   inspectOps=(ns/"${resource_namespace}" "${managedKafkaCR}" "${kafkaCR}" --dest-dir "${inspectDir}")
 
@@ -33,13 +33,13 @@ function main() {
 
   oc -n "${resource_namespace}" adm inspect "${inspectOps[@]}" > "${inspectDir}"/ocadm.log 2>&1
 
-  oc exec -n "${resource_namespace}" "${kafkaStatefulSet}" -c kafka -- sh /opt/kafka/bin/kafka-topics.sh \
+  oc exec -n "${resource_namespace}" "${service}" -c kafka -- sh /opt/kafka/bin/kafka-topics.sh \
     --bootstrap-server localhost:9096 --list > "${inspectDir}"/kafka-topics.txt 2>&1
 
-  oc exec -n "${resource_namespace}" "${kafkaStatefulSet}" -c kafka -- sh /opt/kafka/bin/kafka-consumer-groups.sh \
+  oc exec -n "${resource_namespace}" "${service}" -c kafka -- sh /opt/kafka/bin/kafka-consumer-groups.sh \
     --bootstrap-server localhost:9096 --all-groups --describe  > "${inspectDir}"/kafka-consumer-groups.txt 2>&1
 
-  oc exec -n "${resource_namespace}" "${kafkaStatefulSet}" -c kafka -- sh /opt/kafka/bin/kafka-acls.sh \
+  oc exec -n "${resource_namespace}" "${service}" -c kafka -- sh /opt/kafka/bin/kafka-acls.sh \
     --bootstrap-server localhost:9096 --list > "${inspectDir}"/kafka-acls.txt 2>&1
 
   get-transaction-info
@@ -53,7 +53,7 @@ function main() {
 
 function get-transaction-info() {
     local broker_ids
-    broker_ids=$(oc exec -n "${resource_namespace}" "${kafkaStatefulSet}" -c kafka -- \
+    broker_ids=$(oc exec -n "${resource_namespace}" "${service}" -c kafka -- \
                           ./bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9096 \
                            | grep 9096 | sed -e 's/^.*id: //' -e 's/ rack.*$//')
 
@@ -61,11 +61,11 @@ function get-transaction-info() {
     txDir="${inspectDir}/kafka-transactions"
     mkdir -p "${txDir}"
 
-    oc exec -n "${resource_namespace}" "${kafkaStatefulSet}" -c kafka -- sh /opt/kafka/bin/kafka-transactions.sh \
+    oc exec -n "${resource_namespace}" "${service}" -c kafka -- sh /opt/kafka/bin/kafka-transactions.sh \
        --bootstrap-server localhost:9096 list > "${txDir}"/kafka-transactions-list.txt 2>&1
 
     for b in ${broker_ids}; do
-        oc exec -n "${resource_namespace}" "${kafkaStatefulSet}" -c kafka -- sh /opt/kafka/bin/kafka-transactions.sh \
+        oc exec -n "${resource_namespace}" "${service}" -c kafka -- sh /opt/kafka/bin/kafka-transactions.sh \
            --bootstrap-server localhost:9096 find-hanging \
            --max-transaction-timeout "${max_transaction_timeout:-15}" \
            --broker-id "${b}" > "${txDir}/kafka-transactions-hanging-${b}.txt" 2>&1 &

--- a/scripts/CEE/get-kafka-instance-state/metadata.yaml
+++ b/scripts/CEE/get-kafka-instance-state/metadata.yaml
@@ -54,6 +54,12 @@ rbac:
     - verbs:
         - "list"
       apiGroups:
+        - "core.strimzi.io"
+      resources:
+        - "strimzipodsets"
+    - verbs:
+        - "list"
+      apiGroups:
         - "discovery.k8s.io"
       resources:
         - "endpointslice"


### PR DESCRIPTION
This is a draft pull request to get feedback and test some changes.
Changing the oc exec commands to use services instead of statefulsets. Strimzi is moving away from statefulsets, so we want this script to be able to support both approaches.