### PR TITLE
OSD-13035 - Add label support for script metadata

### DIFF
--- a/hack/metadata.schema.json
+++ b/hack/metadata.schema.json
@@ -40,6 +40,26 @@
         "type": "string"
       }
     },
+    "labels": {
+      "type": "array",
+      "description": "Labels that apply to this script",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "description": "Key of the label",
+            "type": "string"
+          },
+          "values": {
+            "description": "Values for the label",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
     "envs": {
       "type": "array",
       "description": "The environment variables declared on the script",

--- a/hack/metadata.schema.json
+++ b/hack/metadata.schema.json
@@ -51,7 +51,7 @@
             "type": "string"
           },
           "description": {
-            "description": "A bried description of the label",
+            "description": "A brief description of the label",
             "type": "string"
           },
           "values": {

--- a/hack/metadata.schema.json
+++ b/hack/metadata.schema.json
@@ -50,6 +50,10 @@
             "description": "Key of the label",
             "type": "string"
           },
+          "description": {
+            "description": "A bried description of the label",
+            "type": "string"
+          },
           "values": {
             "description": "Values for the label",
             "type": "array",


### PR DESCRIPTION
Manage Scripts require a label as part of their metadata. This property enables the consumers to differentiate between scripts that are meant for only specific scenarios as opposed to scripts that are meant for general usage.

This PR adds label property to Managed Scripts metadata.