### PR TITLE
OSD-13036 - Add cluster compatibility labels to example script

### DIFF
--- a/scripts/SREP/example/metadata.yaml
+++ b/scripts/SREP/example/metadata.yaml
@@ -7,6 +7,12 @@ allowedGroups:
   - CSSRE
   - CEE
   - MTSRE
+labels:
+  - key: OSD_TYPES
+    description: Compatible cluster types for this script
+    values:
+      - OSD
+      - HyperShift
 rbac:
     roles:
       - namespace: "openshift-monitoring"


### PR DESCRIPTION
Resolves: [OSD-13036](https://issues.redhat.com//browse/OSD-13036)

This PR updates the example script to demonstrate how to use labels on managed scripts. The intention is to provide an example so that other contributors can follow and add labels appropriately to their own scripts after testing.