### PR TITLE
Extend pcap-collector script to upload to SFTP and add pcap filters flag

### DIFF
--- a/scripts/CEE/pcap-collector/metadata.yaml
+++ b/scripts/CEE/pcap-collector/metadata.yaml
@@ -2,17 +2,25 @@ file: script.sh
 name: pcap-collector
 shortDescription: Captures traffic on nodes and produce gzipped pcap file.
 description: |
-  Capture network traffic with tcpdump on a node
+  Capture network traffic with tcpdump on a node and then send the capture to the case SFTP server and ticket.
   
-  The response is a gzipped pcap file.
+  This script will only work if a secret exists in the managed scripts namespace that contains a valid single-use
+  SFTP token.
 
-  Examples:
-    # Capture traffic on node ip-10-0-253-170.ap-southeast-2.compute.internal for 10 mins
-    ocm backplane managedjob create CEE/pcap-collector -p TIME=600 -p NODE=ip-10-0-253-170.ap-southeast-2.compute.internal
-    
-    # Getting the resulting pcap file
-    ocm backplane managedjob logs <JOBNAME> | gunzip > node.pcap
-author: John Roche
+  How to use:
+    0. Get the case number from your support case. It is the case_id from this URL format. https://access.redhat.com/support/cases/#/case/{case_id}/discussion
+    1. Have your username and password you use to login to access.redhat.com ready.
+    2. Check whether your user is internal or not. This will be true or false. Run `curl -u username https://access.redhat.com/hydra/rest/contacts/sso/username | jq  .isInternal` with the username and password from step 1.
+    2. Run `curl -u username https://access.redhat.com/hydra/rest/v1/sftp/token/upload/temporary` with your username and password from Step 1.
+    3. Add the token returned in Step 2 to this secret (and delete it if it already exists in the namespace):
+      oc create secret generic pcap-collector-creds --from-literal=username=username_from_step_1 --from-literal=internal=result_from_step_2 --from-literal=password=token_from_step_3  --from-literal=caseid=support_case_number_step_0 -n openshift-backplane-managed-scripts
+    4. Run the collector on the node in question:
+      ocm backplane managedjob create CEE/pcap-collector -p TIME=600 -p NODE=ip-10-0-253-170.ap-southeast-2.compute.internal
+    5. If the job completes, a gzipped pcap file should be available at your case URL.
+
+    See https://source.redhat.com/groups/public/openshiftplatformsre/wiki/how_to_use_the_must_gather_operator for inspiration and reference.
+
+author: John Roche, Hector Kemp
 allowedGroups:
   - SREP
   - CEE
@@ -49,7 +57,16 @@ rbac:
       apiGroups:
         - "config.openshift.io"
       resources:
-        - "networks"        
+        - "networks"
+    - verbs:
+        - "get"
+        - "delete"
+      apiGroups:
+        - ""
+      resources:
+        - "secrets"
+      resourceNames:
+        - "pcap-collector-creds"
 envs:
   - key: "NODE"
     description: "The node name"
@@ -57,4 +74,7 @@ envs:
   - key: "TIME"
     description: "Time in seconds. Can't be greater than 900 seconds (15 mins)"
     optional: false
+  - key: "FILTERS"
+    description: "A valid set of PCAP filters for use in tcpdump"
+    optional: true
 language: bash

--- a/scripts/CEE/pcap-collector/script.sh
+++ b/scripts/CEE/pcap-collector/script.sh
@@ -13,23 +13,28 @@ fi
 NS="openshift-backplane-managed-scripts"
 OUTPUTFILE="/tmp/capture-${NODE}.pcap"
 PODNAME="pcap-collector-${NODE}"
+SECRET_NAME="pcap-collector-creds"
+CURRENT_TIMESTAMP=$(date --utc +%Y%m%d_%H%M%SZ)
+SFTP_FILENAME="pcap-collector-${CURRENT_TIMESTAMP}.tar.gz"
+FTP_HOST="sftp.access.redhat.com"
+SFTP_OPTIONS="-o BatchMode=no -o StrictHostKeyChecking=no -b"
 
 ALL_NODES=$(oc get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 if [[ ! "${ALL_NODES[*]}" =~ ${NODE} ]]
 then
-    echo -e "There is no node with name $NODE in this cluster" >&2
+    echo -e "There is no node with name ${NODE} in this cluster" >&2
     exit 1
 fi
 
 if [ "$(oc -n ${NS} get pod "${PODNAME}" -o jsonpath='{.metadata.name}' 2>/dev/null)" == "$PODNAME" ]
 then
-    echo -e "There is already a capture pod $PODNAME in $NS namespace. Please investigate and remove if necessary" >&2
+    echo -e "There is already a capture pod ${PODNAME} in ${NS} namespace. Please investigate and remove if necessary" >&2
     exit 1
 fi
 
 NETWORKTYPE=$(oc get network cluster -o jsonpath='{.spec.networkType}')
 
-case "$NETWORKTYPE" in
+case "${NETWORKTYPE}" in
     "OpenShiftSDN") INTERFACE="vxlan_sys_4789"
     ;;
     "OVNKubernetes") INTERFACE="genev_sys_6081"
@@ -39,9 +44,11 @@ case "$NETWORKTYPE" in
     ;;
 esac
 
+# Smoke test to check that the secret exists before creating the pod
+oc -n $NS get secret "${SECRET_NAME}" 1>/dev/null
 
 #Create the capture pod
-oc create -f - >/dev/null 2>&1 <<EOF
+oc create -f -  >/dev/null 2>&1 <<EOF
 apiVersion: v1
 kind: Pod
 metadata:
@@ -51,7 +58,10 @@ spec:
   privileged: true
   hostNetwork: true
   restartPolicy: Never
-  containers:
+  volumes:
+  - name: pcap-upload-volume
+    emptyDir: {}
+  initContainers:
   - name: pcap-collector
     image: quay.io/app-sre/srep-network-toolbox:latest
     image-pull-policy: Always
@@ -60,17 +70,90 @@ spec:
     - '-c'
     - |-
       #!/bin/bash
-
       set -e
 
-      tcpdump -G ${TIME} -W 1 -w ${OUTPUTFILE} -i ${INTERFACE} -nn -s0 > /dev/null 2>&1
-      gzip ${OUTPUTFILE} --stdout
+      # https://stackoverflow.com/questions/25731643/how-to-schedule-tcpdump-to-run-for-a-specific-period-of-time
+      # tcpdump -G just hangs if there is no traffic (so use safer timeout command)
+      timeout --preserve-status ${TIME} tcpdump -W 1 -w ${OUTPUTFILE} -i ${INTERFACE} -nn -s0 ${FILTERS} 1> /dev/null
+
+      tar -czf /home/upload/${SFTP_FILENAME} ${OUTPUTFILE}
+    volumeMounts:
+    - mountPath: /home/upload
+      name: pcap-upload-volume
     securityContext:
       capabilities:
         add: ["NET_ADMIN", "NET_RAW"]
       runAsUser: 1001
     nodeSelector:
       kubernetes.io/hostname: ${NODE}
+  containers:
+  # Adapted from https://github.com/openshift/must-gather-operator/blob/7805956e1ded7741c66711215b51eaf4de775f5c/build/bin/upload
+  - name: pcap-uploader
+    image: quay.io/app-sre/must-gather-operator
+    image-pull-policy: Always
+    command:
+    - '/bin/bash'
+    - '-c'
+    - |-
+      #!/bin/bash
+      set -e
+
+      if [ -z "\${caseid}" ] || [ -z "\${username}" ] || [ -z "\${SSHPASS}" ];
+      then
+        echo "Error: Required Parameters have not been provided. Make sure the ${SECRET_NAME} secret exists in namespace openshift-backplane-managed-scripts. Exiting..."
+        exit 1
+      fi
+
+      echo "Uploading '${SFTP_FILENAME}' to Red Hat Customer SFTP Server for case \${caseid}"
+
+      REMOTE_FILENAME=\${caseid}_${SFTP_FILENAME}
+
+      if [[ "\${internal_user}" == true ]]; then
+        # internal users must upload to a different path on the sftp
+        REMOTE_FILENAME="\${username}/\${REMOTE_FILENAME}"
+      fi
+
+      # upload file and detect any errors
+      echo "Uploading ${SFTP_FILENAME}..."
+      sshpass -e sftp ${SFTP_OPTIONS} - \${username}@${FTP_HOST} << "
+          put /home/mustgather/${SFTP_FILENAME} \${REMOTE_FILENAME}
+          bye
+      "
+
+
+      if [[ \$? == 0 ]];
+      then
+        echo "Successfully uploaded '${SFTP_FILENAME}' to Red Hat SFTP Server for case \${caseid}!"
+      else
+        echo "Error: Upload to Red Hat Customer SFTP Server failed. Make sure that you are not using the same SFTP token more than once."
+        exit 1
+      fi
+    volumeMounts:
+    # This directory needs to be used, as it has the correct user/group permissions set up in the must gather container.
+    # See https://github.com/openshift/must-gather-operator/blob/7805956e1ded7741c66711215b51eaf4de775f5c/build/bin/user_setup
+    - mountPath: /home/mustgather
+      name: pcap-upload-volume
+    env:
+    - name: username
+      valueFrom:
+        secretKeyRef:
+          name: ${SECRET_NAME}
+          key: username
+    - name: SSHPASS
+      valueFrom:
+        secretKeyRef:
+          name: ${SECRET_NAME}
+          key: password
+    - name: caseid
+      valueFrom:
+        secretKeyRef:
+          name: ${SECRET_NAME}
+          key: caseid
+    - name: internal_user
+      valueFrom:
+        secretKeyRef:
+          name: ${SECRET_NAME}
+          key: internal
 EOF
 
 while [ "$(oc -n ${NS} get pod "${PODNAME}" -o jsonpath='{.status.phase}' 2>/dev/null)" != "Succeeded" ];
@@ -78,13 +161,19 @@ do
   if [ "$(oc -n ${NS} get pod "${PODNAME}" -o jsonpath='{.status.phase}' 2>/dev/null)" == "Failed" ];
   then
     echo "The pcap collector pod has failed. The logs are:"
-    oc -n $NS logs "$PODNAME"
-    oc -n $NS delete pod "$PODNAME"
+    # Do not error if uploader pod is still in initialising state
+    oc -n $NS logs "${PODNAME}" -c pcap-collector || true
+    oc -n $NS logs "${PODNAME}" -c pcap-uploader || true
+    oc -n $NS delete secret "${SECRET_NAME}" >/dev/null 2>&1
+    oc -n $NS delete pod "${PODNAME}" >/dev/null 2>&1
     exit 1
   fi
   sleep 30
 done
 
-oc -n $NS logs "$PODNAME" > "$OUTPUTFILE"
-oc -n $NS delete pod "$PODNAME" >/dev/null 2>&1
-cat "$OUTPUTFILE"
+oc -n $NS delete secret "${SECRET_NAME}" >/dev/null 2>&1
+oc -n $NS logs "${PODNAME}" -c pcap-collector
+oc -n $NS logs "${PODNAME}" -c pcap-uploader
+oc -n $NS delete pod "${PODNAME}"  >/dev/null 2>&1
+
+echo "PCAP file successfully uploaded to case!"


### PR DESCRIPTION
[OSD-12040](https://issues.redhat.com/browse/OSD-12040)
[OSD-12258](https://issues.redhat.com/browse/OSD-12258)

### Intro
This pull request extends the managed script `pcap-collector` to upload files of arbitrary size to the support case SFTP folder, similar to the [must gather operator](https://github.com/openshift/must-gather-operator). It also adds the ability to add `pcap_filters` (like `not tcp` or `icmp`) as a flag to the script, allowing the user to drill down on traffic they want to sniff.

### How to use it
It takes much inspiration from how to use existing [must-gathers](https://source.redhat.com/groups/public/openshiftplatformsre/wiki/how_to_use_the_must_gather_operator). The basic process is to upload a secret with your username, sftp token, internal user status, and caseid as the parameters, and then trigger the script. If the pcap collection was successful, it will be uploaded to the case as a gzipped file. If it is unsuccessful, the logs can be printed out using the usual managed script command.
Detailed instructions are found here:
https://github.com/openshift/managed-scripts/blob/f2d2598581323f9ebe5b75a9288a914a37c2e98e/scripts/CEE/pcap-collector/metadata.yaml

### How it works
It re-uses most of the logic from the origin script.sh, but instead of being a self-contained process that pipes output to stdout, the `pcap-collector` will instead write its output to a shared volume, which will be read by the `pcap-uploader` container, which will upload it to the case ID if the secret exists and is valid.
Inspiration for the `pcap-uploader` is taken from https://github.com/openshift/must-gather-operator/blob/7805956e1ded7741c66711215b51eaf4de775f5c/build/bin/upload, and the `must-gather-operator` image is used for the main upload container, as all of the necessary security work has been done to make sure the file is uploaded securely.
If the `pcap-collector` or `pcap-uploader` error out, or if the secret does not exist, the script container will dump its logs, and delete the secret. Otherwise it will connect securely using the single-use token (stored in the `SSHPASS` environment variable) and send it to user's sftp folder (prefixed with the case number depending on whether the user is internal or not).

### To test
1. Create a staging cluster.
2. Create a container that pings `google.com` over tcp to generate some random traffic we will sniff using the collector:
```
oc run traffic-generator --image=quay.io/app-sre/srep-network-toolbox -- bash -c 'dnf install -y nmap && nping --tcp-connect -c 0 -p 80 google.com'
```
3. `ocm-container` into your test cluster. Create a secret, following the instructions in https://github.com/openshift/managed-scripts/blob/f2d2598581323f9ebe5b75a9288a914a37c2e98e/scripts/CEE/pcap-collector/metadata.yaml. Log out.
4. cd into managed-scripts/scripts/CEE/pcap-collector/
5. Create a testjob for n seconds. It should hopefully show up on the case as a gzipped pcap file when it's done.

### Open questions
- Will CEE users have permission to create the necessary secret in the `openshift-backplane-managed-scripts` namespace?
- Are there any glaring security risks in my code, or other things I need to worry about?

### Tasks
- [ ] Add permissions in https://github.com/openshift/managed-cluster-config/tree/master/deploy/backplane to allow CEE/SREP to create/get/delete this secret in the managed scripts ns. 
