### PR TITLE
Fix EOF error with sshpass in pcap-collector

### DIFF
--- a/scripts/CEE/pcap-collector/script.sh
+++ b/scripts/CEE/pcap-collector/script.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC1039
 
 set -e
 
@@ -115,11 +116,10 @@ spec:
 
       # upload file and detect any errors
       echo "Uploading ${SFTP_FILENAME}..."
-      sshpass -e sftp ${SFTP_OPTIONS} - \${username}@${FTP_HOST} << "
+      sshpass -e sftp ${SFTP_OPTIONS} - \${username}@${FTP_HOST} << EOF
           put /home/mustgather/${SFTP_FILENAME} \${REMOTE_FILENAME}
           bye
-      "
-
+      EOF
 
       if [[ \$? == 0 ]];
       then


### PR DESCRIPTION
Fixes an error that was auto-fixed by `ShellCheck` that causes an error with `sftp` inside the pod we create in the script. We ignore the double EOF because I don't think there's any other way to do it. 