### PR TITLE
OSD-15321 fix get sa token

### DIFF
--- a/scripts/SREP/get-targets-down/metadata.yaml
+++ b/scripts/SREP/get-targets-down/metadata.yaml
@@ -18,11 +18,11 @@ rbac:
             resources:
             - "serviceaccounts"
           - verbs:
-            - "get"
+            - "create"
             apiGroups:
             - ""
             resources:
-            - "secrets"
+            - "serviceaccounts/token"
     clusterRoleRules:
     - verbs:
       - "get"

--- a/scripts/SREP/get-targets-down/script.sh
+++ b/scripts/SREP/get-targets-down/script.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-TOKEN="$(oc -n openshift-monitoring sa get-token prometheus-k8s)"
+TOKEN="$(oc -n openshift-monitoring create token prometheus-k8s)"
 
 TARGETS_JSON="$(curl -G -s -k -H "Authorization: Bearer $TOKEN" "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091/api/v1/targets")"
 TARGETS_DOWN="$(jq -r '.data.activeTargets[] | select(.health=="down") | .labels.pod' <<< "$TARGETS_JSON")"


### PR DESCRIPTION
`oc sa get-token` is deprecated. In 4.11+ there's no secret associated with SA. We will need to use `oc create token <SA>` to get a token instead.

Tested changes in 4.10, 4.11 and 4.12, work as expected.