### PR TITLE
[MGDCTRS-2112] - redirecting stderr to file in get-rhoc-connector-info script

### DIFF
--- a/scripts/CEE/get-rhoc-connector-info/get-rhoc-connector-info.sh
+++ b/scripts/CEE/get-rhoc-connector-info/get-rhoc-connector-info.sh
@@ -13,9 +13,9 @@ oc get \
     ManagedConnector,KameletBinding,Integration,IntegrationKit,KafkaConnect,KafkaConnector,Deployment,ReplicaSet,Pod,PodDisruptionBudget,NetworkPolicy,ConfigMap,Service,EndpointSlice \
     -l cos.bf2.org/connector.id="${connector_id}" \
     --all-namespaces \
-    -o yaml > "${outputDir}/resources.yaml"
+    -o yaml &> "${outputDir}/resources.yaml"
 
-NAMESPACED_NAMES=$(oc get pods --selector=cos.bf2.org/connector.id="${connector_id}" --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}{";"}{.metadata.name}{" "}{end}')
+NAMESPACED_NAMES=$(oc get pods --selector=cos.bf2.org/connector.id="${connector_id}" --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}{";"}{.metadata.name}{" "}{end}' 2> ${outputDir}/collect-namespaces.log)
 NAMESPACE=""
 
 for NAMESPACED_NAME in $NAMESPACED_NAMES; do
@@ -24,15 +24,15 @@ for NAMESPACED_NAME in $NAMESPACED_NAMES; do
 
     if [ -z "${nologs+x}" ]; then
         # Collecting logs for pod ${POD} in namespace ${NAMESPACE}
-        oc logs "${POD}" --namespace "${NAMESPACE}" | sed -e 's/\x1b\[[0-9;]*m//g' > "${outputDir}/log-${NAMESPACE}-${POD}.txt"
+        oc logs "${POD}" --namespace "${NAMESPACE}" | sed -e 's/\x1b\[[0-9;]*m//g' &> "${outputDir}/log-${NAMESPACE}-${POD}.txt"
     fi
 done
 
 # Collecting events for namespace ${NAMESPACE}
-oc get events --namespace "${NAMESPACE}" -o yaml > "${outputDir}/events-${NAMESPACE}.yaml"
+oc get events --namespace "${NAMESPACE}" -o yaml &> "${outputDir}/events-${NAMESPACE}.yaml"
 
 # collect events in text format as well
-oc get events --namespace "${NAMESPACE}" > "${outputDir}/events-${NAMESPACE}.txt"
+oc get events --namespace "${NAMESPACE}" &> "${outputDir}/events-${NAMESPACE}.txt"
 
 # tar up all collected data to stdout
 # users can collect the data by running

--- a/scripts/CEE/get-rhoc-connector-info/get-rhoc-connector-info.sh
+++ b/scripts/CEE/get-rhoc-connector-info/get-rhoc-connector-info.sh
@@ -15,7 +15,7 @@ oc get \
     --all-namespaces \
     -o yaml &> "${outputDir}/resources.yaml"
 
-NAMESPACED_NAMES=$(oc get pods --selector=cos.bf2.org/connector.id="${connector_id}" --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}{";"}{.metadata.name}{" "}{end}' 2> ${outputDir}/collect-namespaces.log)
+NAMESPACED_NAMES=$(oc get pods --selector=cos.bf2.org/connector.id="${connector_id}" --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}{";"}{.metadata.name}{" "}{end}' 2> "${outputDir}"/collect-namespaces.log)
 NAMESPACE=""
 
 for NAMESPACED_NAME in $NAMESPACED_NAMES; do


### PR DESCRIPTION
Fixing [MGDCTRS-2112](https://issues.redhat.com//browse/MGDCTRS-2112). stderr output needs to be redirected to a file and not go into the pod's log. 