### PR TITLE
OSD-15149 - Creating a new describe-nodes backplane scripts

### DIFF
--- a/scripts/SREP/describe-nodes/README.md
+++ b/scripts/SREP/describe-nodes/README.md
@@ -1,0 +1,44 @@
+# describe-nodes script
+
+## Purpose
+
+Provide the full functionality of `oc describe nodes`, as the standard `oc describe nodes` in backplane restricts access to customer workload information.
+It supports 4 different modes for listing the nodes: 
+* requesting all nodes
+* Requesting nodes from a list
+* Requesting types of nodes (master, infra, worker)
+* Requesting nodes that match a selector
+
+## Parameters and usage 
+### Script usage
+
+```bash
+usage: describe-nodes [--all | --master | --infra | --worker | --nodes <node>,<node>,...]
+  --all      : Describe all nodes in the cluster
+  --master   : Describe the master nodes in the cluster
+  --infra    : Describe the infra nodes in the cluster
+  --worker   : Describe the worker nodes in the cluster
+  --selector : A Label selector to pass to oc describe nodes
+  --nodes    : Describe the listed nodes in the cluster.  The list comprises of the node name separated by a comma with no spaces
+  --help
+
+Argument precedence as only one mode can be used at a time: (the first available is used)
+  --nodes
+  --selector
+  --all
+  --master and|or --worker --and|or infra
+```
+
+### Usage with managed-scripts
+
+For usage with managed-scripts, the options need to be passed through the `SCRIPT_PARAMETERS` environment variable. Here are some examples : 
+
+```bash
+ocm backplane managedjob create SREP/describe-node -p SCRIPT_PARAMETERS="--all"
+
+ocm backplane managedjob create SREP/describe-node -p SCRIPT_PARAMETERS="--master --infra"
+
+ocm backplane managedjob create SREP/describe-node -p SCRIPT_PARAMETERS="--nodes ip-10-0-137-48.us-east-2.compute.internal,ip-10-0-135-110.us-east-2.compute.internal" 
+
+ocm backplane managedjob create SREP/describe-node -p SCRIPT_PARAMETERS="--selector node-role.kubernetes.io=infra"
+```

--- a/scripts/SREP/describe-nodes/README.md
+++ b/scripts/SREP/describe-nodes/README.md
@@ -14,19 +14,22 @@ It supports 4 different modes for listing the nodes:
 
 ```bash
 usage: describe-nodes [--all | --master | --infra | --worker | --nodes <node>,<node>,...]
-  --all      : Describe all nodes in the cluster
-  --master   : Describe the master nodes in the cluster
-  --infra    : Describe the infra nodes in the cluster
-  --worker   : Describe the worker nodes in the cluster
-  --selector : A Label selector to pass to oc describe nodes
-  --nodes    : Describe the listed nodes in the cluster.  The list comprises of the node name separated by a comma with no spaces
-  --help
+  -a, --all             : Describe all nodes in the cluster
+  -m, --master          : Describe the master nodes in the cluster
+  -i, --infra           : Describe the infra nodes in the cluster
+  -w, --worker          : Describe the worker nodes in the cluster
+  -l, --selector        : A Label selector to pass to oc describe nodes
+  -n, --nodes, --node   : Specify the nodes to describe in the cluster separated by a ',' with no spaces
+  -d, --debug           : Enable debugging
+  -h, --help            : Print this help
 
 Argument precedence as only one mode can be used at a time: (the first available is used)
+  --help
   --nodes
   --selector
   --all
   --master and|or --worker --and|or infra
+  The --debug argument can be used at anytime"
 ```
 
 ### Usage with managed-scripts

--- a/scripts/SREP/describe-nodes/metadata.yaml
+++ b/scripts/SREP/describe-nodes/metadata.yaml
@@ -1,0 +1,86 @@
+file: script.sh
+name: describe-nodes
+description: Provide the full functionality of `oc describe nodes`, as the standard `oc describe nodes` in backplane restricts access to customer workload information.
+author: dsquirre
+allowedGroups: 
+  - SREP
+  - CEE
+  - CSSRE
+  - MTSRE
+rbac:
+    roles:
+      - namespace: "openshift-machine-api"
+        rules:
+          - verbs:
+            - "get"
+            - "list"
+            - "watch"
+            - "create"
+            - "delete"
+            apiGroups:
+            - "machine.openshift.io"
+            resources:
+            - "machines"
+      - namespace: "openshift-etcd"
+        rules:
+          - verbs:
+            - "get"
+            - "list"
+            - "watch"
+            - "create"
+            apiGroups:
+            - ""
+            resources:
+            - "pods"
+          - verbs:
+            - "create"
+            apiGroups:
+            - ""
+            resources:
+            - "pods/exec"
+          - verbs:
+            - "get"
+            - "list"
+            - "delete"
+            apiGroups:
+            - ""
+            resources:
+            - "secrets"
+    clusterRoleRules:
+        - verbs:
+            - "get"
+            - "list"
+            - "watch"
+          apiGroups:
+            - "upgrade.managed.openshift.io"
+          resources:
+            - "upgradeconfigs"
+        - verbs:
+            - "get"
+            - "list"
+            - "watch"
+          apiGroups:
+            - ""
+          resources:
+            - "nodes"
+        - verbs:
+            - "get"
+            - "list"
+            - "watch"
+            - "patch"
+          apiGroups:
+            - "operator.openshift.io"
+          resources:
+            - "etcds"
+        - verbs:
+            - "get"
+          apiGroups:
+            - "config.openshift.io"
+          resources:
+            - "clusteroperators"
+            - "clusterversions"
+envs:
+  - key: "SCRIPT_PARAMETERS"
+    description: "Parameters to be passed to the script. You can set the variable to '--help' to get list of supported parameters"
+    optional: true
+language: bash

--- a/scripts/SREP/describe-nodes/metadata.yaml
+++ b/scripts/SREP/describe-nodes/metadata.yaml
@@ -9,78 +9,27 @@ allowedGroups:
   - MTSRE
 rbac:
     roles:
-      - namespace: "openshift-machine-api"
+      - namespace: "kube-node-lease"
         rules:
-          - verbs:
-            - "get"
-            - "list"
-            - "watch"
-            - "create"
-            - "delete"
-            apiGroups:
-            - "machine.openshift.io"
-            resources:
-            - "machines"
-      - namespace: "openshift-etcd"
-        rules:
-          - verbs:
-            - "get"
-            - "list"
-            - "watch"
-            - "create"
-            apiGroups:
-            - ""
-            resources:
-            - "pods"
-          - verbs:
-            - "create"
-            apiGroups:
-            - ""
-            resources:
-            - "pods/exec"
-          - verbs:
-            - "get"
-            - "list"
-            - "delete"
-            apiGroups:
-            - ""
-            resources:
-            - "secrets"
+          - apiGroups: ['coordination.k8s.io']
+            resources: ['leases']
+            verbs:     ['get', 'list']
     clusterRoleRules:
-        - verbs:
-            - "get"
-            - "list"
-            - "watch"
-          apiGroups:
-            - "upgrade.managed.openshift.io"
-          resources:
-            - "upgradeconfigs"
-        - verbs:
-            - "get"
-            - "list"
-            - "watch"
-          apiGroups:
-            - ""
-          resources:
-            - "nodes"
-        - verbs:
-            - "get"
-            - "list"
-            - "watch"
-            - "patch"
-          apiGroups:
-            - "operator.openshift.io"
-          resources:
-            - "etcds"
-        - verbs:
-            - "get"
-          apiGroups:
-            - "config.openshift.io"
-          resources:
-            - "clusteroperators"
-            - "clusterversions"
+        - apiGroups: ['']
+          resources: ['nodes']
+          verbs:     ['get', 'list']
+        - apiGroups: ['']
+          resources: ['pods']
+          verbs:     ['get', 'list']
 envs:
   - key: "SCRIPT_PARAMETERS"
     description: "Parameters to be passed to the script. You can set the variable to '--help' to get list of supported parameters"
     optional: true
 language: bash
+labels:
+  - key: OSD_TYPES
+    description: Compatible cluster types for this script
+    values:
+      - OSD
+      - HyperShift
+      

--- a/scripts/SREP/describe-nodes/script.sh
+++ b/scripts/SREP/describe-nodes/script.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# Replace a master machine.
+# Input:
+#  (Env) MACHINE
+#    name of the machine resource in cluster
+
+# Exit on error
+set -e
+# Treat unset variables as error
+set -u
+# Print expanded commands with arguments before executing them
+# set -x
+# Set the return value in a set of pipes to the rightmost failed command
+set -o pipefail
+
+## Display error and end
+function error-out() {
+  echo "$0: $1"
+  echo "\
+usage: describe-nodes [--all | --master | --infra | --worker | --nodes <node>,<node>,...]
+  --all      : Describe all nodes in the cluster
+  --master   : Describe the master nodes in the cluster
+  --infra    : Describe the infra nodes in the cluster
+  --worker   : Describe the worker nodes in the cluster
+  --selector : A Label selector to pass to oc describe nodes
+  --nodes    : Describe the listed nodes in the cluster.  The list comprises of the node name seperated by a comma with no spaces  ; 
+  --help     : Print this help
+
+Argument precedence as only one mode can be used at a time: (the first available is used)
+  --nodes
+  --selector
+  --all
+  --master and|or --worker --and|or infra"
+  exit 1
+}
+
+function add2nodes() {
+  nodes="$nodes${1}"
+}
+
+function list-selector() {
+    oc get nodes -l ${1} | tail -n +2 | cut -d " " -f 1 | tr "\n" ","
+}
+
+all=flase
+master=flase
+infra=flase
+worker=flase
+nodes=""
+selector=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --help)
+      error-out "Help!"
+      ;;
+    --all)
+      all=true
+      shift # past argument
+      ;;
+    --master)
+      master=true
+      shift # past argument
+      ;;
+    --infra)
+      infra=true
+      shift # past argument
+      ;;
+    --worker)
+      worker=1
+      shift # past argument
+      ;;
+    --nodes)
+      if [ ! -z "$nodes" ]
+      then
+        error-out "Only 1 '--nodes' argument can be provided"
+      fi
+      nodes=${2}
+      shift # past argument
+      shift # past value
+      ;;
+    --selector)
+      if [ ! -z "$selector" ]
+      then
+        error-out "Only 1 '--selector' argument can be provided"
+      fi
+      selector=${2}
+      shift # past argument
+      shift # past value
+      ;;
+    -*|--*)
+      error-out "Unknown option $1"
+      ;;
+    *)
+      error-out "Unknown argument"
+      ;;
+  esac
+done
+
+# If --nodes is supplied use that and ignore all other arguments
+# else if --selector is supplied use that ignore the otheres arguments
+# else if --all is supplied use that ignore the otheres arguments
+# else if any of the --master or --infra or --worker arguments are supplied use them all
+if [ ! -z "$nodes" ]
+then
+  break
+elif [ ! -z "$selector" ]
+then
+  nodes = list-selector ${selector}
+elif [ "$all" = true ]
+then
+  add2nodes $(list-selector "node-role.kubernetes.io/master")
+  add2nodes $(list-selector "node-role.kubernetes.io=infra")
+  add2nodes $(list-selector "node-role.kubernetes.io!=infra,node-role.kubernetes.io/worker")
+else
+  if [ "$master" = true ]
+  then
+    add2nodes $(list-selector "node-role.kubernetes.io/master")
+  fi
+  if [ "$infra" = true ]
+  then
+    add2nodes $(list-selector "node-role.kubernetes.io=infra")
+  fi
+  if [ "$worker" = true ]
+  then
+    add2nodes $(list-selector "node-role.kubernetes.io!=infra,node-role.kubernetes.io/worker")
+  fi
+fi
+
+if [ ! -n "$nodes" ] 
+then
+  error-out "No nodes selected"
+fi
+
+nodes=$(echo ${nodes} | tr "," " ")
+echo oc describe nodes $nodes
+exit 0

--- a/scripts/SREP/describe-nodes/script.sh
+++ b/scripts/SREP/describe-nodes/script.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
-# Replace a master machine.
-# Input:
-#  (Env) MACHINE
-#    name of the machine resource in cluster
+# Commnad: describe-nodes
+# Description: Describes the nodes in a cluster by calling `oc decribe nodes`
+#              This is useful to be run as a backplane script where more more authorisation can be provided when compared to the standard bacplane cli access. 
 
 # Exit on error
 set -e
@@ -16,80 +15,131 @@ set -o pipefail
 
 ## Display error and end
 function error-out() {
-  echo "$0: $1"
   echo "\
 usage: describe-nodes [--all | --master | --infra | --worker | --nodes <node>,<node>,...]
-  --all      : Describe all nodes in the cluster
-  --master   : Describe the master nodes in the cluster
-  --infra    : Describe the infra nodes in the cluster
-  --worker   : Describe the worker nodes in the cluster
-  --selector : A Label selector to pass to oc describe nodes
-  --nodes    : Describe the listed nodes in the cluster.  The list comprises of the node name seperated by a comma with no spaces  ; 
-  --help     : Print this help
+  -a, --all             : Describe all nodes in the cluster
+  -m, --master          : Describe the master nodes in the cluster
+  -i, --infra           : Describe the infra nodes in the cluster
+  -w, --worker          : Describe the worker nodes in the cluster
+  -l, --selector        : A Label selector to pass to oc describe nodes
+  -n, --nodes, --node   : Specify the nodes to describe in the cluster separated by a ',' with no spaces
+  -d, --debug           : Enable debugging
+  -h, --help            : Print this help
 
 Argument precedence as only one mode can be used at a time: (the first available is used)
+  --help
   --nodes
   --selector
   --all
-  --master and|or --worker --and|or infra"
-  exit 1
+  --master and|or --worker --and|or infra
+  The --debug argument can be used at anytime"
+  if [ ! -n "${1-}" ]
+  then 
+    exit 0
+  else
+    echo
+    echo "$0: ERROR: $1"  
+    exit 1
+  fi
 }
 
+# Add argument to the nodes variable
 function add2nodes() {
   nodes="$nodes${1}"
 }
 
+# List nodes that match a specific selector past in as $1
 function list-selector() {
-    oc get nodes -l ${1} | tail -n +2 | cut -d " " -f 1 | tr "\n" ","
+    oc get nodes -l "${1}" --no-headers -o custom-columns=":metadata.name" | tr "\n" ","
 }
 
+# Initialise variables usesd while parsing commandline arguments
 all=flase
 master=flase
 infra=flase
 worker=flase
 nodes=""
 selector=""
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    --help)
-      error-out "Help!"
+
+# Parse command line arguments
+if [ -z ${SCRIPT_PARAMETERS+x} ]
+then
+  error-out "The 'SCRIPT_PARAMETERS' argument has not been provided: via Bacplane script parameter; Or via export if running on the cmdline"
+fi
+# echo "${SCRIPT_PARAMETERS}"
+ARG_ARRAY=( ${SCRIPT_PARAMETERS} )
+# echo "ARG_ARRAY: ${ARG_ARRAY}"
+while [[ ${#ARG_ARRAY[@]} -gt 0 ]]
+do
+  # echo "in while"
+  case ${ARG_ARRAY[0]} in
+    -h|--help)
+      error-out
       ;;
-    --all)
+    -a|--all)
       all=true
-      shift # past argument
+      ARG_ARRAY=("${ARG_ARRAY[@]:1}")  # shift past argument
       ;;
-    --master)
+    -m|--master)
       master=true
-      shift # past argument
+      ARG_ARRAY=("${ARG_ARRAY[@]:1}")  # shift past argument
       ;;
-    --infra)
+    -i|--infra)
       infra=true
-      shift # past argument
+      ARG_ARRAY=("${ARG_ARRAY[@]:1}")  # shift past argument
       ;;
-    --worker)
-      worker=1
-      shift # past argument
+    -w|--worker)
+      worker=true
+      ARG_ARRAY=("${ARG_ARRAY[@]:1}")  # shift past argument
       ;;
-    --nodes)
+    -d|--debug)
+      set -x  # Print expanded commands with arguments
+      ARG_ARRAY=("${ARG_ARRAY[@]:1}")  # shift past argument
+      ;;
+    -n|--node|--nodes)
       if [ ! -z "$nodes" ]
       then
         error-out "Only 1 '--nodes' argument can be provided"
       fi
-      nodes=${2}
-      shift # past argument
-      shift # past value
+      # Check for unset or empty arguments and values that look like a flag/switch
+      if [ ${#ARG_ARRAY[@]} -le 1 ] \
+        || [ -z ${ARG_ARRAY[1]} ] \
+        || [[ ${ARG_ARRAY[1]} =~ ^-.* ]]
+      then
+        error-out "The --nodes requires a list of nodes"
+      fi
+      # Check for ilegal characters in the list of nodes
+      badchars="$(echo ${ARG_ARRAY[1]} | tr -d '[:alnum:]' | tr -d '-' | tr -d '.' | tr -d ',')"
+      if [ ! -z ${badchars} ]
+      then  
+        error-out "'--nodes' can only contain '.|-|,|<alphanumric>' characters.  These characters '${badchars}' are ileagal"
+      fi
+      nodes=${ARG_ARRAY[1]}
+      ARG_ARRAY=("${ARG_ARRAY[@]:2}")  # shift past argument and value
       ;;
-    --selector)
+    -l|--selector)
       if [ ! -z "$selector" ]
       then
         error-out "Only 1 '--selector' argument can be provided"
       fi
-      selector=${2}
-      shift # past argument
-      shift # past value
+      # Check for unset or empty arguments and values that look like a flag/switch
+      if [ ${#ARG_ARRAY[@]} -le 1 ] \
+        || [ -z ${ARG_ARRAY[1]} ] \
+        || [[ ${ARG_ARRAY[1]} =~ ^-.* ]]
+      then
+        error-out "'--selector' must contain a node selector"
+      fi
+      badchars="$(echo ${ARG_ARRAY[1]} | tr -d '[:alnum:]' | tr -d '-' | tr -d '.'  | tr -d '/'  \
+          | tr -d ',' | tr -d ':' | tr -d ' ' | tr -d '(' | tr -d ')' | tr -d '!' | tr -d '=')"
+      if [ ! -z ${badchars} ]
+      then
+        error-out "--selector ilegal caharcters in selector.  These characters '${badchars}' are ileagal"
+      fi
+      selector=${ARG_ARRAY[1]}
+      ARG_ARRAY=("${ARG_ARRAY[@]:2}")  # shift past argument and value
       ;;
     -*|--*)
-      error-out "Unknown option $1"
+      error-out "Unknown option ${ARG_ARRAY[0]}"
       ;;
     *)
       error-out "Unknown argument"
@@ -103,10 +153,10 @@ done
 # else if any of the --master or --infra or --worker arguments are supplied use them all
 if [ ! -z "$nodes" ]
 then
-  break
+  
 elif [ ! -z "$selector" ]
 then
-  nodes = list-selector ${selector}
+  nodes=$(list-selector $selector)
 elif [ "$all" = true ]
 then
   add2nodes $(list-selector "node-role.kubernetes.io/master")
@@ -127,11 +177,13 @@ else
   fi
 fi
 
+# If he nodes variable is empty, it means the no arguments were supplied on the command line
+# Or the selector(s) did not pick any nodes.  This is an error
 if [ ! -n "$nodes" ] 
 then
   error-out "No nodes selected"
 fi
 
 nodes=$(echo ${nodes} | tr "," " ")
-echo oc describe nodes $nodes
+oc describe nodes $nodes
 exit 0


### PR DESCRIPTION
The new script allows any backplane user to gain access to the lost "cluster node resource usage" which was lost durring the RBAC tightening that occurred late last year.

It pretty much runs `oc describe nodes` but provides validation and a few nice arguments to help with choosing specific nodes.