### PR TITLE
added LPSRE to allowedGroups

### DIFF
--- a/scripts/CEE/check-tech-preview-features/metadata.yaml
+++ b/scripts/CEE/check-tech-preview-features/metadata.yaml
@@ -7,7 +7,8 @@ allowedGroups:
   - CEE
   - SREP
   - CSSRE
-  - MTSRE                      
+  - MTSRE
+  - LPSRE                      
 rbac:
     clusterRoleRules:
       - apiGroups:

--- a/scripts/CEE/describe-kafka-transaction/metadata.yaml
+++ b/scripts/CEE/describe-kafka-transaction/metadata.yaml
@@ -7,6 +7,7 @@ allowedGroups:
   - SREP
   - CSSRE
   - CEE
+  - LPSRE
 rbac:
   clusterRoleRules:
     - verbs:

--- a/scripts/CEE/etcd-health-check/metadata.yaml
+++ b/scripts/CEE/etcd-health-check/metadata.yaml
@@ -7,6 +7,7 @@ allowedGroups:
   - CSSRE
   - CEE
   - MTSRE
+  - LPSRE
 rbac:
     roles:
       - namespace: "openshift-etcd"

--- a/scripts/CEE/get-kafka-instance-state/metadata.yaml
+++ b/scripts/CEE/get-kafka-instance-state/metadata.yaml
@@ -12,6 +12,7 @@ allowedGroups:
   - SREP
   - CSSRE
   - CEE
+  - LPSRE
 rbac:
   clusterRoleRules:
     - verbs:

--- a/scripts/CEE/get-rhoc-connector-info/metadata.yaml
+++ b/scripts/CEE/get-rhoc-connector-info/metadata.yaml
@@ -10,6 +10,7 @@ allowedGroups:
   - CSSRE
   - CEE
   - MTSRE
+  - LPSRE
 rbac:
   clusterRoleRules:
     # connectors   

--- a/scripts/CEE/get-rhosak-operators/metadata.yaml
+++ b/scripts/CEE/get-rhosak-operators/metadata.yaml
@@ -12,6 +12,7 @@ allowedGroups:
   - SREP
   - CSSRE
   - CEE
+  - LPSRE
 envs:
   - key: 'since'
     description: "The --since flag is used by the oc adm inspect command. Only return logs newer than a relative duration. Either since can be added or since_time can be added but not both."

--- a/scripts/CEE/list-alerts/metadata.yaml
+++ b/scripts/CEE/list-alerts/metadata.yaml
@@ -7,6 +7,7 @@ allowedGroups:
   - CSSRE
   - CEE
   - MTSRE
+  - LPSRE
 rbac:
     roles:
       - namespace: "openshift-monitoring"

--- a/scripts/CSSRE/get-kafka-topics/metadata.yaml
+++ b/scripts/CSSRE/get-kafka-topics/metadata.yaml
@@ -4,6 +4,7 @@ description: Get topics and partitions details for a given Kafka
 author: Rob Shelly
 allowedGroups:
   - CSSRE
+  - LPSRE
 rbac:
   clusterRoleRules:
     - verbs:

--- a/scripts/CSSRE/get-node-restarts/metadata.yaml
+++ b/scripts/CSSRE/get-node-restarts/metadata.yaml
@@ -4,6 +4,7 @@ description: Lists of nodes that are restarted in the last X minutes
 author: vbommana
 allowedGroups: 
   - CSSRE
+  - LPSRE
 rbac:
   clusterRoleRules:
     - verbs:

--- a/scripts/CSSRE/rolling-restart-brokers/metadata.yaml
+++ b/scripts/CSSRE/rolling-restart-brokers/metadata.yaml
@@ -4,6 +4,7 @@ description: Manually roll the Kafka brokers
 author: Pat Cremin
 allowedGroups:
   - CSSRE
+  - LPSRE
 rbac:
   clusterRoleRules:
     - verbs:

--- a/scripts/CSSRE/under-min-isr-partitions/metadata.yaml
+++ b/scripts/CSSRE/under-min-isr-partitions/metadata.yaml
@@ -5,6 +5,7 @@ description: |
 author: Rob Shelly
 allowedGroups:
   - CSSRE
+  - LPSRE
 rbac:
   clusterRoleRules:
     - verbs:

--- a/scripts/CSSRE/under-replicated-partitions/metadata.yaml
+++ b/scripts/CSSRE/under-replicated-partitions/metadata.yaml
@@ -4,6 +4,7 @@ description: Debug under replicated partitions alert on a cluster and instruct w
 author: Rob Shelly
 allowedGroups:
   - CSSRE
+  - LPSRE
 rbac:
   clusterRoleRules:
     - verbs:

--- a/scripts/SREP/cluster-operator-status/metadata.yaml
+++ b/scripts/SREP/cluster-operator-status/metadata.yaml
@@ -7,6 +7,7 @@ allowedGroups:
   - CSSRE
   - CEE
   - MTSRE
+  - LPSRE
 rbac:
     roles: []
     clusterRoleRules:

--- a/scripts/SREP/describe-nodes/metadata.yaml
+++ b/scripts/SREP/describe-nodes/metadata.yaml
@@ -7,6 +7,7 @@ allowedGroups:
   - CEE
   - CSSRE
   - MTSRE
+  - LPSRE
 rbac:
     roles:
       - namespace: "kube-node-lease"

--- a/scripts/SREP/elasticsearch-status/metadata.yaml
+++ b/scripts/SREP/elasticsearch-status/metadata.yaml
@@ -6,6 +6,7 @@ allowedGroups:
   - SREP
   - CSSRE
   - CEE
+  - LPSRE
 rbac:
     roles:
       - namespace: "openshift-monitoring"

--- a/scripts/SREP/example/metadata.yaml
+++ b/scripts/SREP/example/metadata.yaml
@@ -7,6 +7,7 @@ allowedGroups:
   - CSSRE
   - CEE
   - MTSRE
+  - LPSRE
 labels:
   - key: OSD_TYPES
     description: Compatible cluster types for this script

--- a/scripts/SREP/get-targets-down/metadata.yaml
+++ b/scripts/SREP/get-targets-down/metadata.yaml
@@ -7,6 +7,7 @@ allowedGroups:
   - CSSRE
   - CEE
   - MTSRE
+  - LPSRE
 rbac:
     roles:
       - namespace: "openshift-monitoring"

--- a/scripts/SREP/node-logs/metadata.yaml
+++ b/scripts/SREP/node-logs/metadata.yaml
@@ -7,6 +7,7 @@ allowedGroups:
   - CSSRE
   - CEE
   - MTSRE
+  - LPSRE
 rbac:
     clusterRoleRules:
         - verbs:

--- a/scripts/SREP/tsdb-status/metadata.yaml
+++ b/scripts/SREP/tsdb-status/metadata.yaml
@@ -8,6 +8,7 @@ allowedGroups:
   - CSSRE
   - CEE
   - MTSRE
+  - LPSRE
 rbac:
     roles:
       - namespace: "openshift-monitoring"


### PR DESCRIPTION
lpsre groups is not updated to the allowedGroups in the managed-backplane-scripts after the merge of CSSRE and MTSRE teams,
updated now