### PR TITLE
Managed job library support

### DIFF
--- a/scripts/examples/lib-sourcer/metadata.yaml
+++ b/scripts/examples/lib-sourcer/metadata.yaml
@@ -1,0 +1,9 @@
+file: script.sh
+name: lib-sourcer
+shortDescription: Checks if the directory /foo/bar exists and prints that to the screen.
+description: |
+  A toy example showing how to import bash libraries from the `/libs` directory within a script.
+author: hkemp
+allowedGroups: 
+  - SREP
+language: bash

--- a/scripts/examples/lib-sourcer/script.sh
+++ b/scripts/examples/lib-sourcer/script.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# All files in scripts end up at /managed-scripts in the actual docker container
+# i.e.
+# managed-scripts/scripts/examples/lib-sourcer/lib.sh
+# becomes
+source /managed-scripts/lib/examples/lib.sh
+
+echo_import

--- a/scripts/lib/examples/lib.sh
+++ b/scripts/lib/examples/lib.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+function echo_import() {
+    echo "This is an imported library being used in a managed script."
+}


### PR DESCRIPTION
Rewrite of https://github.com/openshift/managed-scripts/pull/106. 

Adds the ability to `source` a bash library from anywhere within the `scripts` directory.

If a script is in `/scripts/SREP/script.sh`, and the library is also in `/scripts/lib/lib.sh`, it must be sourced like so in `script.sh`:
`source /managed-scripts/lib/lib.sh`. This is due to how the managed scripts are bundled in the `Dockerfile`. 

On staging/production, these will be built in. This behaviour is emulated in backplane test jobs by inlining the library scripts. 