### PR TITLE
Update CEE/cluster-health-check to use oc-hc v0.1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,10 @@ WORKDIR /oc-hc
 RUN curl -sSLf -O $OC_HC_TAR_URL
 
 # Check md5sum for the downloaded tar
-RUN md5sum -b oc-hc-v0.1.2-linux-amd64.tar.gz | grep $OC_HC_MD5
+RUN md5sum -b oc-hc-v0.1.3-linux-amd64.tar.gz | grep $OC_HC_MD5
 
 # Extract the binary
-RUN tar xzf oc-hc-v0.1.2-linux-amd64.tar.gz --directory /out
+RUN tar xzf oc-hc-v0.1.3-linux-amd64.tar.gz --directory /out
 
 # Install aws-cli
 RUN mkdir -p /aws/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN sha256sum --check --ignore-missing sha256sum.txt
 RUN tar --extract --gunzip --no-same-owner --directory /out oc --file *.tar.gz
 
 ### Temporary solution to integrate the oc-hc
-ENV OC_HC_TAR_URL="https://github.com/givaldolins/openshift-cluster-health-check/releases/download/v0.1.2/oc-hc-v0.1.2-linux-amd64.tar.gz"
-ENV OC_HC_MD5="12d21a265fe6da4fa9e520e60386f051"
+ENV OC_HC_TAR_URL="https://github.com/givaldolins/openshift-cluster-health-check/releases/download/v0.1.3/oc-hc-v0.1.3-linux-amd64.tar.gz"
+ENV OC_HC_MD5="e75e9a9801601e53d7ad555b498e7c08"
 RUN mkdir -p /oc-hc
 WORKDIR /oc-hc
 

--- a/scripts/CEE/cluster-health-check/run-oc-hc.sh
+++ b/scripts/CEE/cluster-health-check/run-oc-hc.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Run check
-oc hc cluster
+oc hc cluster -d
 


### PR DESCRIPTION
- v0.1.2 enforced the user to be cluster-admin, which causes the following error when running the managed script:
```
$ ocm backplane testjob logs openshift-job-dev-8jkwn -f
[Info] Using default kubeconfig: /root/.kube/config
[Info] kubeconfig invalid, tryin to use current-context
Checking if user has cluster-admin privileges...
[Error] Something went wrong:   [Error] User is not a cluster-admin. 
```
v0.1.3 removes that check
- Enabled debug mode for error messages
