### PR TITLE
OSD-17639 - Add full hypershift dump

### DIFF
--- a/scripts/CEE/hs-must-gather/README.md
+++ b/scripts/CEE/hs-must-gather/README.md
@@ -1,17 +1,14 @@
 # Hypershift mustgather
-
-This script run must gather commands in both the hosted and management clusters. 
+This script runs hypershift dump command to fetch logs from management cluster HCP namespace and hosted cluster. 
 
 
 ## Usage
 
 Parameters:
 - CLUSTER_NAME: hosted cluster name.
-- DUMP_DIR: Must gather dump directory path.
 
 ```bash
-ocm backplane managedjob create CEE/hs-must-gather -p CLUSTER_NAME=my-hs-cluster-name -p DUMP_DIR=/path/for-dump/
-
+ocm backplane managedjob create CEE/hs-must-gather -p CLUSTER_NAME=my-hs-cluster-name 
 ```
 
 

--- a/scripts/CEE/hs-must-gather/README.md
+++ b/scripts/CEE/hs-must-gather/README.md
@@ -1,4 +1,4 @@
-# Hypershift mustgather
+# HyperShift mustgather
 This script runs hypershift dump command to fetch logs from management cluster HCP namespace and hosted cluster. 
 
 

--- a/scripts/CEE/hs-must-gather/metadata.yaml
+++ b/scripts/CEE/hs-must-gather/metadata.yaml
@@ -37,14 +37,67 @@ rbac:
         - "get"
         - "list"
       apiGroups:
+        - "hypershift.openshift.io"
+      resources:
+        - "awsendpointservices"
+        - "hostedclusters"
+        - "nodepools"
+        - "hostedcontrolplanes"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
         - ""
       resources:
-        - "hostedclusters"    
+        - "nodes"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "infrastructure.cluster.x-k8s.io"
+      resources:
+        - "awsclusters"
+        - "awsmachines"
+        - "awsmachinetemplates"
+        - "kubevirtclusters"
+        - "kubevirtmachinetemplates"
+        - "kubevirtmachines"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "capi-provider.agent-install.openshift.io"
+      resources:
+        - "agentclusters"
+        - "agentmachinetemplates"
+        - "agentmachines"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "cluster.x-k8s.io"
+      resources:
+        - "clusters"
+        - "machinedeployments"
+        - "machines"
+        - "machinesets"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - ""
+      resources:
+        - "secrets"
+    - verbs:
+        - "get"
+        - "list"
+        - "create"
+      apiGroups:
+        - ""
+      resources:
+        - "pods/portforward"
 envs:
   - key: "CLUSTER_NAME"
     description: "Hosted cluster name"
     optional: false
-  - key: "DUMP_DIR"
-    description: "Must gather directory"
-    optional: false  
 language: bash

--- a/scripts/CEE/hs-must-gather/metadata.yaml
+++ b/scripts/CEE/hs-must-gather/metadata.yaml
@@ -97,7 +97,7 @@ rbac:
       resources:
         - "pods/portforward"
 envs:
-  - key: "CLUSTER_NAME"
-    description: "Hosted cluster name"
+  - key: "CLUSTER_ID"
+    description: "Hosted cluster internal ID"
     optional: false
 language: bash

--- a/scripts/CEE/hs-must-gather/script.sh
+++ b/scripts/CEE/hs-must-gather/script.sh
@@ -4,46 +4,30 @@ set -e
 set -o nounset
 set -o pipefail
 
-#define vars 
-HS_HCP_MG_DIR="$DUMP_DIR/managment-cluster"
-HS_DP_MG_DIR="$DUMP_DIR/hs-cluster"
-HS_BINARY_PATH=" /usr/local/bin/hypershift"
+# Define expected values 
+HS_BINARY_PATH="/usr/local/bin/hypershift"
 
- # check hypershift binary
-function hasHipershiftBinary {
-    echo "Checking hypershift binary available in $HS_BINARY_PATH" 
-    if test -f "$HS_BINARY_PATH";
-     then
-        return 1
-     else
-        return 0
-    fi
-   
-}
-
-# Init must gather for Hosted controll plane
-function initMustGatherforHCP {
-    echo "Init must gather for management cluster namespace $HS_NAMESPACE, and data will saved to $HS_HCP_MG_DIR" 
-
-    return 1
-}
-
-# Init must gather for hosted cluster
-function initMustGatherforHC {
-    echo "Init must gather for hosted cluster $CLUSTER_NAME, and data will saved to $HS_DP_MG_DIR" 
-
-    return 1
-}
-
-# Get 
-if hasHipershiftBinary "$1" ; then
-    if initMustGatherforMC "$1" ; then
-        initMustGatherforHC
-    fi
-
-    
-else
-    echo "hypershift binary not available in $HS_BINARY_PATH path" 
+# Check if hypershift binary is in place 
+if [ ! -f "$HS_BINARY_PATH" ]; then
+  echo "Hypershift binary not available in $HS_BINARY_PATH path" 
+  exit 1
 fi
 
+# Sanity check for multiple namespaces matching label
+HCP_NS_LIST_LENGTH=$(oc get namespace -l api.openshift.com/name="$CLUSTER_NAME" -o json | jq -r '.items | length')
+if [ "$HCP_NS_LIST_LENGTH" -ne 1 ]; then
+  echo "Number of HCP namespaces matching $CLUSTER_NAME must be 1, $HCP_NS_LIST_LENGTH found"
+  exit 1
+fi
+
+# Fetch the target HCP namespace for the cluster name
+HCP_NS=$(oc get namespace -l api.openshift.com/name="$CLUSTER_NAME" -o json | jq -r '.items[0].metadata.labels["kubernetes.io/metadata.name"]')
+
+echo "Executing hypershift dump on $HCP_NS for cluster $CLUSTER_NAME"
+hypershift dump cluster --dump-guest-cluster --namespace "$HCP_NS" --name "$CLUSTER_NAME" --artifact-dir "$CLUSTER_NAME"
+
+echo "Hypershift dump has been saved in $PWD/$CLUSTER_NAME"
+ls -alh "$PWD"/"$CLUSTER_NAME"
+
+# End
 exit 0

--- a/scripts/CEE/hs-must-gather/script.sh
+++ b/scripts/CEE/hs-must-gather/script.sh
@@ -13,7 +13,7 @@ if [ ! -f "$HS_BINARY_PATH" ]; then
   exit 1
 fi
 
-# Sanity check for multiple namespaces matching label
+# Sanity check to make sure desired cluster namespace exists
 HCP_NS_LIST_LENGTH=$(oc get namespace -l api.openshift.com/id="$CLUSTER_ID" -o json | jq -r '.items | length')
 if [ "$HCP_NS_LIST_LENGTH" -ne 1 ]; then
   echo "Number of HCP namespaces matching $CLUSTER_ID must be 1, $HCP_NS_LIST_LENGTH found"
@@ -24,7 +24,7 @@ fi
 HCP_NS=$(oc get namespace -l api.openshift.com/id="$CLUSTER_ID" -o json | jq -r '.items[0].metadata.labels["kubernetes.io/metadata.name"]')
 
 echo "Executing hypershift dump on $HCP_NS for cluster $CLUSTER_ID"
-hypershift dump cluster --dump-guest-cluster --namespace "$HCP_NS" --name "$CLUSTER_ID" --artifact-dir "$CLUSTER_ID"
+hypershift dump cluster --dump-guest-cluster --namespace "$HCP_NS" --name "$CLUSTER_ID" --artifact-dir "$CLUSTER_ID" --archive-dump=false
 
 echo "Hypershift dump has been saved in $PWD/$CLUSTER_ID"
 ls -alh "$PWD"/"$CLUSTER_ID"

--- a/scripts/CEE/hs-must-gather/script.sh
+++ b/scripts/CEE/hs-must-gather/script.sh
@@ -24,7 +24,7 @@ fi
 HCP_NS=$(oc get namespace -l api.openshift.com/id="$CLUSTER_ID" -o json | jq -r '.items[0].metadata.labels["kubernetes.io/metadata.name"]')
 
 echo "Executing hypershift dump on $HCP_NS for cluster $CLUSTER_ID"
-#hypershift dump cluster --dump-guest-cluster --namespace "$HCP_NS" --name "$CLUSTER_ID" --artifact-dir "$CLUSTER_ID"
+hypershift dump cluster --dump-guest-cluster --namespace "$HCP_NS" --name "$CLUSTER_ID" --artifact-dir "$CLUSTER_ID"
 
 echo "Hypershift dump has been saved in $PWD/$CLUSTER_ID"
 ls -alh "$PWD"/"$CLUSTER_ID"

--- a/scripts/CEE/hs-must-gather/script.sh
+++ b/scripts/CEE/hs-must-gather/script.sh
@@ -9,25 +9,25 @@ HS_BINARY_PATH="/usr/local/bin/hypershift"
 
 # Check if hypershift binary is in place 
 if [ ! -f "$HS_BINARY_PATH" ]; then
-  echo "Hypershift binary not available in $HS_BINARY_PATH path" 
+  echo "HyperShift binary not found in $HS_BINARY_PATH path" 
   exit 1
 fi
 
 # Sanity check for multiple namespaces matching label
-HCP_NS_LIST_LENGTH=$(oc get namespace -l api.openshift.com/name="$CLUSTER_NAME" -o json | jq -r '.items | length')
+HCP_NS_LIST_LENGTH=$(oc get namespace -l api.openshift.com/id="$CLUSTER_ID" -o json | jq -r '.items | length')
 if [ "$HCP_NS_LIST_LENGTH" -ne 1 ]; then
-  echo "Number of HCP namespaces matching $CLUSTER_NAME must be 1, $HCP_NS_LIST_LENGTH found"
+  echo "Number of HCP namespaces matching $CLUSTER_ID must be 1, $HCP_NS_LIST_LENGTH found"
   exit 1
 fi
 
 # Fetch the target HCP namespace for the cluster name
-HCP_NS=$(oc get namespace -l api.openshift.com/name="$CLUSTER_NAME" -o json | jq -r '.items[0].metadata.labels["kubernetes.io/metadata.name"]')
+HCP_NS=$(oc get namespace -l api.openshift.com/id="$CLUSTER_ID" -o json | jq -r '.items[0].metadata.labels["kubernetes.io/metadata.name"]')
 
-echo "Executing hypershift dump on $HCP_NS for cluster $CLUSTER_NAME"
-hypershift dump cluster --dump-guest-cluster --namespace "$HCP_NS" --name "$CLUSTER_NAME" --artifact-dir "$CLUSTER_NAME"
+echo "Executing hypershift dump on $HCP_NS for cluster $CLUSTER_ID"
+#hypershift dump cluster --dump-guest-cluster --namespace "$HCP_NS" --name "$CLUSTER_ID" --artifact-dir "$CLUSTER_ID"
 
-echo "Hypershift dump has been saved in $PWD/$CLUSTER_NAME"
-ls -alh "$PWD"/"$CLUSTER_NAME"
+echo "Hypershift dump has been saved in $PWD/$CLUSTER_ID"
+ls -alh "$PWD"/"$CLUSTER_ID"
 
 # End
 exit 0


### PR DESCRIPTION
This PR adds the RBAC rules and commands that enabled hs-must-gather to do a full hypershift dump.

Resolves: 
* [OSD-17639](https://issues.redhat.com/browse/OSD-17639)
* [OSD-17850](https://issues.redhat.com/browse/OSD-17850)

Sample run:
```
$ ocm backplane testjob create -f -p CLUSTER_NAME=taf-mg    
	Test job openshift-job-dev-ttlhp created successfully

	Run "ocm backplane testjob get openshift-job-dev-ttlhp" for details
	Run "ocm backplane testjob logs openshift-job-dev-ttlhp" for job logs	

TestId: openshift-job-dev-ttlhp

$ ocm backplane testjob logs openshift-job-dev-ttlhp
Executing hypershift dump on ocm-staging-25gfjutppguvfur1923uq33ub5nmortn for cluster taf-mg
2023-08-10T15:14:29Z    INFO    Dumping guestcluster    {"target": "taf-mg/hostedcluster-taf-mg"}
2023-08-10T15:16:49Z    INFO    oc adm inspect returned an error    {"args": ["adm", "inspect", "--dest-dir", "taf-mg/hostedcluster-taf-mg", "--kubeconfig", "/tmp/kubeconfig-3126819884", "customresourcedefinition.apiextensions.k8s.io,controllerrevision.apps,daemonset.apps,deployment.apps,replicaset.apps,statefulset.apps,job.batch,clusteroperator.config.openshift.io,configmap,endpoints,event,namespace,node,persistentvolume,persistentvolumeclaim,pod,replicationcontroller,service,clusterrole.rbac.authorization.k8s.io,clusterrolebinding.rbac.authorization.k8s.io,role.rbac.authorization.k8s.io,rolebinding.rbac.authorization.k8s.io,securitycontextconstraints.security.openshift.io,csidriver.storage.k8s.io,csinode.storage.k8s.io,storageclass.storage.k8s.io,volumeattachment.storage.k8s.io,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontent.snapshot.storage.k8s.io"], "error": "exit status 1", "output": "Gathering data for ns/openshift-monitoring...\nGathering data for ns/openshift-console-operator...\nGathering data for ns/openshift-console...\nGathering data for ns/openshift-cluster-storage-operator...\nGathering data for ns/openshift-dns-operator...\nGathering data for ns/openshift-dns...\nGathering data for ns/openshift-image-registry...\nGathering data for ns/openshift-ingress-operator...\nGathering data for ns/openshift-ingress...\nGathering data for ns/openshift-ingress-canary...\nGathering data for ns/openshift-insights...\nGathering data for ns/openshift-config...\nGathering data for ns/openshift-config-managed...\nGathering data for ns/openshift-kube-apiserver-operator...\nGathering data for ns/openshift-kube-apiserver...\nGathering data for ns/openshift-kube-controller-manager...\nGathering data for ns/openshift-kube-controller-manager-operator...\nGathering data for ns/openshift-kube-scheduler...\nGathering data for ns/openshift-kube-scheduler-operator...\nGathering data for ns/openshift-kube-storage-version-migrator...\nGathering data for ns/openshift-kube-storage-version-migrator-operator...\nGathering data for ns/openshift-user-workload-monitoring...\nGathering data for ns/openshift-multus...\nGathering data for ns/openshift-ovn-kubernetes...\nGathering data for ns/openshift-host-network...\nGathering data for ns/openshift-network-diagnostics...\nGathering data for ns/openshift-network-operator...\nGathering data for ns/openshift-cloud-network-config-controller...\nGathering data for ns/openshift-cluster-node-tuning-operator...\nGathering data for ns/openshift-apiserver-operator...\nGathering data for ns/openshift-apiserver...\nGathering data for ns/openshift-controller-manager-operator...\nGathering data for ns/openshift-controller-manager...\nGathering data for ns/openshift-cluster-samples-operator...\nGathering data for ns/openshift-operator-lifecycle-manager...\nGathering data for ns/openshift-service-ca-operator...\nGathering data for ns/openshift-service-ca...\nGathering data for ns/openshift-cluster-csi-drivers...\nGathering data for ns/addon-operator...\nGathering data for ns/dedicated-admin...\nGathering data for ns/default...\nGathering data for ns/kube-node-lease...\nGathering data for ns/kube-public...\nGathering data for ns/kube-system...\nGathering data for ns/open-cluster-management-agent...\nGathering data for ns/open-cluster-management-agent-addon...\nGathering data for ns/openshift...\nGathering data for ns/openshift-authentication...\nGathering data for ns/openshift-authentication-operator...\nGathering data for ns/openshift-backplane...\nGathering data for ns/openshift-backplane-cee...\nGathering data for ns/openshift-backplane-cse...\nGathering data for ns/openshift-backplane-csm...\nGathering data for ns/openshift-backplane-lpsre...\nGathering data for ns/openshift-backplane-managed-scripts...\nGathering data for ns/openshift-backplane-mobb...\nGathering data for ns/openshift-backplane-srep...\nGathering data for ns/openshift-backplane-tam...\nGathering data for ns/openshift-cloud-credential-operator...\nGathering data for ns/openshift-cluster-machine-approver...\nGathering data for ns/openshift-cluster-version...\nGathering data for ns/openshift-config-operator...\nGathering data for ns/openshift-console-user-settings...\nGathering data for ns/openshift-customer-monitoring...\nGathering data for ns/openshift-etcd...\nGathering data for ns/openshift-infra...\nGathering data for ns/openshift-logging...\nGathering data for ns/openshift-machine-api...\nGathering data for ns/openshift-machine-config-operator...\nGathering data for ns/openshift-marketplace...\nGathering data for ns/openshift-must-gather-operator...\nGathering data for ns/openshift-node...\nGathering data for ns/openshift-operators...\nGathering data for ns/openshift-operators-redhat...\nGathering data for ns/openshift-route-controller-manager...\nGathering data for ns/openshift-route-monitor-operator...\nWrote inspect data to taf-mg/hostedcluster-taf-mg.\nerror: errors occurred while gathering data:\n    [skipping gathering secrets/support due to error: secrets \"support\" not found, skipping gathering sharedconfigmaps.sharedresource.openshift.io due to error: the server doesn't have a resource type \"sharedconfigmaps\", skipping gathering sharedsecrets.sharedresource.openshift.io due to error: the server doesn't have a resource type \"sharedsecrets\"]\n"}
2023-08-10T15:16:49Z    INFO    Successfully dumped guest cluster    {"duration": "2m20.16693913s"}
2023-08-10T15:16:49Z    INFO    Archiving dump    {"command": "tar", "args": ["-cvzf", "hypershift-dump.tar.gz", "cluster-scoped-resources", "event-filter.html", "hostedcluster-taf-mg", "namespaces", "network_logs", "timestamp"]}
2023-08-10T15:17:15Z    INFO    Successfully archived dump    {"duration": "25.84405216s"}
Hypershift dump has been saved in /root/taf-mg
total 58M
drwxr-xr-x. 6 root root  176 Aug 10 15:16 .
dr-xr-x---. 1 root root   33 Aug 10 15:13 ..
drwxr-xr-x. 3 root root   18 Aug 10 15:13 cluster-scoped-resources
-rw-r--r--. 1 root root 3.3K Aug 10 15:13 event-filter.html
drwxr-xr-x. 4 root root  122 Aug 10 15:16 hostedcluster-taf-mg
-rw-r--r--. 1 root root  58M Aug 10 15:17 hypershift-dump.tar.gz
drwxr-xr-x. 5 root root  135 Aug 10 15:13 namespaces
drwxr-xr-x. 2 root root 4.0K Aug 10 15:14 network_logs
-rw-r--r--. 1 root root  550 Aug 10 15:13 timestamp
 
 
```