### PR TITLE
OSD-17611 : Adding information on Managed Scripts release cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ The staging environment is pinned to consume the main branch of the managed-scri
 
 Once every 3 weeks.
 
-For more information, please refer [Backplane Release Cycles](https://source.redhat.com/groups/public/sre/wiki/backplane_user_documentation)
+In case of you have changes that have immediate impact and would need an immediate promotion, please reach out to:
+Backplane team (alias : @backplane-team) in #sd-ims-backplane slack channel 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ The staging environment is pinned to consume the main branch of the managed-scri
 
 ### Production:
 
-Every 3 weeks.
+Once every 3 weeks.
 
 For more information, please refer [Backplane Release Cycles](https://source.redhat.com/groups/public/sre/wiki/backplane_user_documentation)

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ The staging environment is pinned to consume the main branch of the managed-scri
 
 Once every 3 weeks.
 
-In case of you have changes that have immediate impact and would need an immediate promotion, please reach out to:
+In case you have changes that have immediate impact and would need an immediate promotion, please reach out to:
 Managed-scripts team (alias : @managed-scripts) in #sd-ims-backplane slack channel 

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ The staging environment is pinned to consume the main branch of the managed-scri
 Once every 3 weeks.
 
 In case of you have changes that have immediate impact and would need an immediate promotion, please reach out to:
-Backplane team (alias : @backplane-team) in #sd-ims-backplane slack channel 
+Managed-scripts team (alias : @managed-scripts) in #sd-ims-backplane slack channel 

--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ the supported languages.
 ## `metadata.yaml`
 
 All `metadata.yaml` shall pass validation against `hack/metadata.schema.json` see [here](https://json-schema.org/) for more details
+
+## Release Cycle
+
+Managed Scripts follows the following release cycle :
+
+### Staging:
+
+The staging environment will use the latest main branch of the managed-scripts github repo.
+
+### Production:
+
+Every 3 weeks.
+
+For more information, please refer [Backplane Relase Cycles](https://source.redhat.com/groups/public/sre/wiki/backplane_user_documentation#isPasted5)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All `metadata.yaml` shall pass validation against `hack/metadata.schema.json` se
 
 ## Release Cycle
 
-Managed Scripts follows the following release cycle :
+Managed Scripts has the following release cycle:
 
 ### Staging:
 

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ The staging environment is pinned to consume the main branch of the managed-scri
 
 Every 3 weeks.
 
-For more information, please refer [Backplane Relase Cycles](https://source.redhat.com/groups/public/sre/wiki/backplane_user_documentation#isPasted5)
+For more information, please refer [Backplane Release Cycles](https://source.redhat.com/groups/public/sre/wiki/backplane_user_documentation)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Managed Scripts has the following release cycle:
 
 ### Staging:
 
-The staging environment will use the latest main branch of the managed-scripts github repo.
+The staging environment is pinned to consume the main branch of the managed-scripts repository.
 
 ### Production:
 


### PR DESCRIPTION
As a part of [OSD-17611](https://issues.redhat.com//browse/OSD-17611), this PR intends to add information on Managed Scripts .