### PR TITLE
Add supreeth7 as an approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,5 @@ approvers:
 - bmeng
 - cblecker
 - feichashao
-- wanghaoran1988
-maintainers:
+- supreeth7
 - wanghaoran1988


### PR DESCRIPTION
Not sure how this was missed, adding myself (@supreeth7) to the approvers' list of managed-scripts as one of the maintainers.

This PR also removes the maintainers list as it isn't relevant for GitHub (only GitLab).