### PR TITLE
Removing the sensitive files from the hypershift dump

### DIFF
--- a/scripts/CEE/hs-must-gather/README.md
+++ b/scripts/CEE/hs-must-gather/README.md
@@ -1,6 +1,9 @@
 # HyperShift mustgather
-This script runs hypershift dump command to fetch logs from management cluster HCP namespace and hosted cluster. 
+This script executes the hypershift dump command to collect logs and relevant information from
+both the management cluster's HCP namespace and the hosted cluster. 
 
+Importantly, after gathering the data, the script also scans and removes files containing potentially
+sensitive information to ensure safer sharing and archiving.
 
 ## Usage
 
@@ -10,6 +13,3 @@ Parameters:
 ```bash
 ocm backplane managedjob create CEE/hs-must-gather -p CLUSTER_NAME=my-hs-cluster-name 
 ```
-
-
-

--- a/scripts/CEE/hs-must-gather/README.md
+++ b/scripts/CEE/hs-must-gather/README.md
@@ -8,8 +8,8 @@ sensitive information to ensure safer sharing and archiving.
 ## Usage
 
 Parameters:
-- CLUSTER_NAME: hosted cluster name.
+- CLUSTER_NAME: hosted cluster id.
 
 ```bash
-ocm backplane managedjob create CEE/hs-must-gather -p CLUSTER_NAME=my-hs-cluster-name 
+ocm backplane managedjob create CEE/hs-must-gather -p CLUSTER_ID=my-hs-cluster-id
 ```


### PR DESCRIPTION
## What
According to the [OSD-17641](https://issues.redhat.com/browse/OSD-17641) spike, some sensitive files need to be removed from the hypershift dump which contains:
- All Secrets
- certificates in the configMap

Working Jira Task: https://issues.redhat.com/browse/OSD-17960

## Acceptance criteria: 

- Remove the above files list from tarball from the existing hypershift dump
- Compress the files with the same format with the new list of files
