### PR TITLE
osd-17784: addind check-jsonschema to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,7 @@ COPY scripts /managed-scripts
 
 # Install python packages
 RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install tabulate openshift-client --user
+RUN python3 -m pip install tabulate openshift-client check-jsonschema --user
 
 # Validate
 RUN oc completion bash > /etc/bash_completion.d/oc


### PR DESCRIPTION
We are adding the package check-jsonschema to this Dockerfile in order to have the package available on the existing managed-scripts image. This will be used for the json schema validation.

After this PR, we will raise a new one in order to update the schema validation script. 