### PR TITLE
osd-17784: fixing json schema and a metadata.yaml

### DIFF
--- a/hack/metadata.schema.json
+++ b/hack/metadata.schema.json
@@ -122,22 +122,19 @@
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "required": true
+          }
         },
         "apiGroups": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "required": true
+          }
         },
         "resources": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "required": true
+          }
         },
         "resourceNames": {
           "type": "array",
@@ -145,23 +142,23 @@
             "type": "string"
           }
         }
-      }
+      },
+      "required": [ "verbs", "apiGroups", "resources" ]
     },
     "roleRule": {
       "type": "object",
       "properties": {
         "namespace": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "rules": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/rules"
-          },
-          "required": true
+          }
         }
-      }
+      },
+      "required": [ "namespace", "rules" ]
     }
   }
 }

--- a/scripts/LPSRE/rolling-restart-brokers/metadata.yaml
+++ b/scripts/LPSRE/rolling-restart-brokers/metadata.yaml
@@ -13,7 +13,7 @@ rbac:
         - "apps"
       resources:
         - "statefulsets"
-        - verbs:
+    - verbs:
         - "get"
         - "list"
       apiGroups:
@@ -34,9 +34,6 @@ rbac:
         - "kafka.strimzi.io"
       resources:
         - "kafkas"
-    - verbs:
-        - "get"
-        - "list"
 envs:
   - key: "kafka_namespace"
     description: "Namespace for the Kafka instance you want to query"


### PR DESCRIPTION
After testing the json files with the new 'check-jsonschema' package towards the existing jsonschema, it has been identified some issues with the structure of the jsonschema and also with the metadata.yaml of rolling-restart-brokers script. This commit is to fix both files.