### PR TITLE
osd-18431: schema_validation.sh improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build: isclean validation shellcheck pyflakes
 
 .PHONY: validation
 validation:
-	./hack/schema_validation.sh
+	./hack/schema_validation.sh $(SCRIPTS)
 
 .PHONY: shellcheck
 shellcheck:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ the supported languages.
 
 All `metadata.yaml` shall pass validation against `hack/metadata.schema.json` see [here](https://json-schema.org/) for more details
 
+### Validation methods:
+
+    1. In order to check all `metadata.yaml` from all scripts, you can run the command below from your managed-scripts root directory:
+
+    `make validation`
+
+    2. To run the validation just for specifics scripts, you can use the command below parsing the scripts as arguments:
+
+    `make validation SCRIPTS="<script1> <scriptN>"`
+
+    example:
+
+    `make validation SCRIPTS="under-replicated-partition rolling-restart-broker"`
+
+
 ## Release Cycle
 
 Managed Scripts has the following release cycle:

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ All `metadata.yaml` shall pass validation against `hack/metadata.schema.json` se
 
 ### Validation methods:
 
-    1. In order to check all `metadata.yaml` from all scripts, you can run the command below from your managed-scripts root directory:
+1. In order to check all `metadata.yaml` from all scripts, you can run the command below from your managed-scripts root directory:
 
     `make validation`
 
-    2. To run the validation just for specifics scripts, you can use the command below parsing the scripts as arguments:
+2. To run the validation just for specifics scripts, you can use the command below parsing the scripts as arguments:
 
     `make validation SCRIPTS="<script1> <scriptN>"`
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a repository storing OpenShift Dedicated managed scripts.
 
 `scripts` folder contains various scripts used by different teams.
 
-`hack` contains various helper script for CI/CD tooling and building
+`hack` contains various helper script for CI/CD tooling and building.
 
 Each Red Hat managed role has a dedicated directory under root and each of the contains any number
 of scripts.
@@ -19,7 +19,7 @@ the supported languages.
 
 ## `metadata.yaml`
 
-All `metadata.yaml` shall pass validation against `hack/metadata.schema.json` see [here](https://json-schema.org/) for more details
+All `metadata.yaml` shall pass validation against `hack/metadata.schema.json` see [here](https://json-schema.org/) for more details.
 
 ### Validation methods:
 

--- a/hack/schema_validation.sh
+++ b/hack/schema_validation.sh
@@ -23,73 +23,71 @@ CONTAINER_PATH=/json
 # change to the managed-scripts directory on your repository
 cd $(dirname $0)/..
 
-# funtion to present the help
+# function to present the help
 usage() {
-cat <<EOF >&2
-Usage: $0 <options> [script1] [scriptN]
+  cat <<EOF >&2
+  Usage: $0 <options> [script1] [scriptN]
 
-  Check Managed Scripts metadata.yaml files against the JSON Schema.
+    Check Managed Scripts metadata.yaml files against the JSON Schema.
 
-  The script can be run with no arguments, which runs against all files found 
-  in the managed-scripts directory, or it can be specified the scripts to be
-  validated.
+    The script can be run with no arguments, which runs against all files found 
+    in the managed-scripts directory, or it can be specified the scripts to be
+    validated.
 
-  Options:
+    Options:
 
-    -h, --help        Shows the script usage.
-
+      -h, --help        Shows the script usage.
 EOF
-  exit -1
 }
 
-# funtion which validates the list of scripts and adds the container path to each file found
+# function which validates the list of scripts and adds the container path to each file found
 yamlList() {
 
-if [ ! -z "$listYamlFiles" ]; then
-  for i in $listYamlFiles
-  do
-    yamlFiles+="$CONTAINER_PATH$i "
-  done
-  # calls check_validation function to run the validation on the scripts
-  check_validation
-else
-  echo "error: no file was found."
-  exit 1
-fi
+  if [ ! -z "$listYamlFiles" ]; then
+    for i in $listYamlFiles
+    do
+      yamlFiles+="$CONTAINER_PATH$i "
+    done
+    # calls check_validation function to run the validation on the scripts
+    check_validation
+  else
+    echo "error: no file was found."
+    exit 1
+  fi
 
 }
 
-# funtion to validate the Yaml files
+# function to validate the Yaml files
 check_validation() {
 
-echo "validating the jsonschema for $yamlFiles"
-$CONTAINER_ENGINE run --rm -v $(pwd):$CONTAINER_PATH quay.io/app-sre/managed-scripts:latest /root/.local/bin/check-jsonschema --schemafile $CONTAINER_PATH/hack/metadata.schema.json $yamlFiles
+  echo "validating the jsonschema for $yamlFiles"
+  $CONTAINER_ENGINE run --rm -v $(pwd):$CONTAINER_PATH quay.io/app-sre/managed-scripts:latest /root/.local/bin/check-jsonschema --schemafile $CONTAINER_PATH/hack/metadata.schema.json $yamlFiles
 
 }
 
-# funtion that list all files in the manage-scripts directory
+# function that list all files in the manage-scripts directory
 all() {
 
-# list all yaml files
-listYamlFiles="$(find . -name 'metadata.yaml' | cut -c 2- ) "
+  # list all yaml files
+  listYamlFiles="$(find . -name 'metadata.yaml' | cut -c 2- ) "
 
-# calls yamList function to prepare the scripts to be validated
-yamlList
+  # calls yamList function to prepare the scripts to be validated
+  yamlList
 
 }
 
-# funtion that list the scripts passed as arguments
+# function that list the scripts passed as arguments
 partial() {
 
-# list the number of arguments
-for ((i = 1; i <= $#; i++ ));
-do
-  # list the yaml files based on the arguments
-  listYamlFiles+="$(find ./scripts/*/${!i} -name 'metadata.yaml' | cut -c 2- ) "
-done
+  # list the number of arguments
+  for ((i = 1; i <= $#; i++ ));
+  do
+    # list the yaml files based on the arguments
+    listYamlFiles+="$(find ./scripts/*/${!i} -name 'metadata.yaml' | cut -c 2- ) "
+  done
 
-# calls yamList function to prepare the scripts to be validated
-yamlList
+  # calls yamList function to prepare the scripts to be validated
+  yamlList
 
 }
 

--- a/hack/yamltojson.py
+++ b/hack/yamltojson.py
@@ -1,5 +1,0 @@
-import sys, yaml, json, os
-
-with open(sys.argv[1], 'r') as yaml_in, open("./" + ''.join((sys.argv[1].split('.')[:-1])) + ".json", "w") as json_out:
-    yaml_object = yaml.safe_load(yaml_in)
-    json.dump(yaml_object, json_out)


### PR DESCRIPTION
- Improved the hack/schema_validation.sh to run the validation also to single/multiple scripts if needed.
- Now, the script is intended to run a single container which reads a variable with all scripts to test. This optimized a lot the process.
- The check-jsonschema package also permits to run the validation on YAML files. So, the script was adapted to run the validation directly instead of converting them first to JSON. This also optimized the process a bit more.
- For the new feature, it was necessary to change the Makefile to consider the arguments.
- The README.md file was updated to present the 2 available validation methods.