### PR TITLE
Add SFTP upload function

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN chmod -R +x /out
 
 FROM registry.access.redhat.com/ubi8/ubi:latest
 RUN  yum -y install --disableplugin=subscription-manager \
-     python3 jq \
+     python3 jq openssh-clients sshpass \
      && yum --disableplugin=subscription-manager clean all
 COPY --from=build-stage0 /out/oc  /usr/local/bin
 COPY --from=build-stage0 /out/oc-hc  /usr/local/bin

--- a/scripts/lib/sftp_upload/lib.sh
+++ b/scripts/lib/sftp_upload/lib.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # Description: provide the sftp_upload function for script to call
+#
+# To import the sftp_upload function,
+# include in your script with
+# source /managed-scripts/lib/sftp_upload/lib.sh
 
 # Fail fast and be aware of exit codes
 set -euo pipefail

--- a/scripts/lib/sftp_upload/lib.sh
+++ b/scripts/lib/sftp_upload/lib.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # Constants
 readonly FTP_HOST="sftp.access.redhat.com"
-readonly SFTP_OPTIONS="-o BatchMode=no -b"
+readonly SFTP_OPTIONS=(-o BatchMode=no -b)
 readonly KNOWN_HOST='sftp.access.redhat.com,35.80.245.1 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCFQ3l2YVJ0r4MNzAZmTV2kg7rPi4WPeJNcNubvOVA4WwBV6cRsYFkIqtB1unBzTXoZHd7+adtZTgUrJ2BExImyLUQaLBu3KKo4CgGeiZMo8dfDvE2tIe/GwGtyho57TtwJVVUCljvFBvbz8+D6VunsQ6kNU53t8qCaBQNm61twTkdAHP9IESJbC7wWJqjmhmOMTav1OKQDtLEsSDc4I+s+h41LvUfw1lA7RSl9eR13TK9ySpN/uW5nBq7nUNWW5OBc3UbvpdQpDXvdUDbW0rQ2EEWvLkKubhk+RSeY/lH8peOeHYQ5ARPYfFDpo5KsKDDdKa9DfnK8N8APgtzM0r+l'
 
 ## Upload a file to sftp.access.redhat.com using the unauthenticated flow.
@@ -17,13 +17,10 @@ readonly KNOWN_HOST='sftp.access.redhat.com,35.80.245.1 ssh-rsa AAAAB3NzaC1yc2EA
 ## Exmaple: sftp_upload ${PWD}/must-gather.tar.gz must-gather.tar.gz
 ## The <destination-filename> should be a filename not a path.
 function sftp_upload() {
-    ## for testing purpose, add to Dockerfile later
-    yum install -y openssh-clients sshpass
-
     ## Set up known hosts file
-    mkdir -p .ssh
-    chmod 700 .ssh
-    echo "${KNOWN_HOST}" > .ssh/known_hosts
+    mkdir -p "${HOME}/.ssh"
+    chmod 700 "${HOME}/.ssh"
+    echo "${KNOWN_HOST}" > "${HOME}/.ssh/known_hosts"
 
     ## Get a one-time upload token
     creds=$(curl --request POST 'https://access.redhat.com/hydra/rest/v2/sftp/token' \
@@ -35,7 +32,7 @@ function sftp_upload() {
     token=$(jq -r '.token' <<< "${creds}")
 
     ## Upload the file
-    sshpass -p "${token}" sftp "${SFTP_OPTIONS}" - "${username}"@"${FTP_HOST}" << EOSSHPASS
+    sshpass -p "${token}" sftp "${SFTP_OPTIONS[@]}" - "${username}"@"${FTP_HOST}" << EOSSHPASS
         put $1 $2
         bye
 EOSSHPASS

--- a/scripts/lib/sftp_upload/lib.sh
+++ b/scripts/lib/sftp_upload/lib.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Description: provide the sftp_upload function for script to call
+
+# Fail fast and be aware of exit codes
+set -euo pipefail
+
+# Constants
+readonly FTP_HOST="sftp.access.redhat.com"
+readonly SFTP_OPTIONS="-o BatchMode=no -b"
+readonly KNOWN_HOST='sftp.access.redhat.com,35.80.245.1 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCFQ3l2YVJ0r4MNzAZmTV2kg7rPi4WPeJNcNubvOVA4WwBV6cRsYFkIqtB1unBzTXoZHd7+adtZTgUrJ2BExImyLUQaLBu3KKo4CgGeiZMo8dfDvE2tIe/GwGtyho57TtwJVVUCljvFBvbz8+D6VunsQ6kNU53t8qCaBQNm61twTkdAHP9IESJbC7wWJqjmhmOMTav1OKQDtLEsSDc4I+s+h41LvUfw1lA7RSl9eR13TK9ySpN/uW5nBq7nUNWW5OBc3UbvpdQpDXvdUDbW0rQ2EEWvLkKubhk+RSeY/lH8peOeHYQ5ARPYfFDpo5KsKDDdKa9DfnK8N8APgtzM0r+l'
+
+## Upload a file to sftp.access.redhat.com using the unauthenticated flow.
+## More about the SFTP server:
+## https://access.redhat.com/articles/5594481
+##
+## Usage: sftp_upload <source-filename> <destination-filename>
+## Exmaple: sftp_upload ${PWD}/must-gather.tar.gz must-gather.tar.gz
+## The <destination-filename> should be a filename not a path.
+function sftp_upload() {
+    ## for testing purpose, add to Dockerfile later
+    yum install -y openssh-clients sshpass
+
+    ## Set up known hosts file
+    mkdir -p .ssh
+    chmod 700 .ssh
+    echo "${KNOWN_HOST}" > .ssh/known_hosts
+
+    ## Get a one-time upload token
+    creds=$(curl --request POST 'https://access.redhat.com/hydra/rest/v2/sftp/token' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{
+    "isAnonymous" : true
+    }')
+    username=$(jq -r '.username' <<< "${creds}")
+    token=$(jq -r '.token' <<< "${creds}")
+
+    ## Upload the file
+    sshpass -p "${token}" sftp "${SFTP_OPTIONS}" - "${username}"@"${FTP_HOST}" << EOSSHPASS
+        put $1 $2
+        bye
+EOSSHPASS
+
+    echo "Uploaded file $1 to ${FTP_HOST}, Anonymous username: ${username}, filename: $2"
+    echo "For more information about SFTP: https://access.redhat.com/articles/5594481"
+    return 0
+}


### PR DESCRIPTION
https://access.redhat.com/articles/5594481

We can allow a managed-script to upload files using the unauthenticated way, so that we don't need to handle any secret in the script. 