### PR TITLE
OSD-17674 Upload the must gather tarball to SFTP

### DIFF
--- a/scripts/CEE/hs-must-gather/README.md
+++ b/scripts/CEE/hs-must-gather/README.md
@@ -5,11 +5,14 @@ both the management cluster's HCP namespace and the hosted cluster.
 Importantly, after gathering the data, the script also scans and removes files containing potentially
 sensitive information to ensure safer sharing and archiving.
 
+The script will upload the compressed dump to the [SFTP](https://access.redhat.com/articles/5594481#TOC32).
+
 ## Usage
 
 Parameters:
-- CLUSTER_NAME: hosted cluster id.
+- CLUSTER_ID: hosted cluster id.
 
+In the management cluster:
 ```bash
 ocm backplane managedjob create CEE/hs-must-gather -p CLUSTER_ID=my-hs-cluster-id
 ```

--- a/scripts/CEE/hs-must-gather/script.sh
+++ b/scripts/CEE/hs-must-gather/script.sh
@@ -4,69 +4,99 @@ set -e
 set -o nounset
 set -o pipefail
 
-# Define expected values 
+source /managed-scripts/lib/sftp_upload/lib.sh
+
+# Define expected values
 HS_BINARY_PATH="/usr/local/bin/hypershift"
+DUMP_DIR="${PWD}/${CLUSTER_ID}"
+TODAY=$(date -u +%Y%m%d)
+TARBALL_NAME="${TODAY}_${CLUSTER_ID}_dump.tar.gz"
+TARBALL_PATH="${DUMP_DIR}/${TARBALL_NAME}"
 
-# Check if hypershift binary is in place 
-if [ ! -f "$HS_BINARY_PATH" ]; then
-  echo "HyperShift binary not found in $HS_BINARY_PATH path" 
-  exit 1
-fi
+# Function to run a hypershift dump on the HCP namespace
+collect_must_gather() {
+  # Check if hypershift binary is in place
+  if [ ! -f "${HS_BINARY_PATH}" ]; then
+    echo "HyperShift binary not found in ${HS_BINARY_PATH} path"
+    exit 1
+  fi
 
-# Sanity check to make sure desired cluster namespace exists
-HCP_NS_LIST_LENGTH=$(oc get namespace -l api.openshift.com/id="$CLUSTER_ID" -o json | jq -r '.items | length')
-if [ "$HCP_NS_LIST_LENGTH" -ne 1 ]; then
-  echo "Number of HCP namespaces matching $CLUSTER_ID must be 1, $HCP_NS_LIST_LENGTH found"
-  exit 1
-fi
+  # Sanity check to make sure desired cluster namespace exists
+  hcp_ns_list_length=$(oc get namespace -l api.openshift.com/id="${CLUSTER_ID}" -o json | jq -r '.items | length')
+  if [ "${hcp_ns_list_length}" -ne 1 ]; then
+    echo "Number of HCP namespaces matching ${CLUSTER_ID} must be 1, ${hcp_ns_list_length} found"
+    exit 1
+  fi
 
-# Fetch the target HCP namespace for the cluster name
-HCP_NS=$(oc get namespace -l api.openshift.com/id="$CLUSTER_ID" -o json | jq -r '.items[0].metadata.labels["kubernetes.io/metadata.name"]')
+  # Fetch the target HCP namespace for the cluster name
+  hcp_ns=$(oc get namespace -l api.openshift.com/id="${CLUSTER_ID}" -o json | jq -r '.items[0].metadata.labels["kubernetes.io/metadata.name"]')
 
-echo "Executing hypershift dump on $HCP_NS for cluster $CLUSTER_ID"
-hypershift dump cluster --dump-guest-cluster --namespace "$HCP_NS" --name "$CLUSTER_ID" --artifact-dir "$CLUSTER_ID" --archive-dump=false
+  # Fetch the HostedCluster name
+  hc_name=$(oc get HostedCluster.hypershift.openshift.io -l api.openshift.com/id="${CLUSTER_ID}" -n "${hcp_ns}" -o json | jq -r '.items[0].metadata.name')
 
-echo "Hypershift dump has been saved in $PWD/$CLUSTER_ID"
-ls -alh "$PWD"/"$CLUSTER_ID"
+  echo "Executing hypershift dump on ${hcp_ns} for cluster ${hc_name}"
+  hypershift dump cluster --dump-guest-cluster --namespace "${hcp_ns}" --name "${hc_name}" --artifact-dir "${DUMP_DIR}" --archive-dump=false
 
+  echo "Hypershift dump has been saved in ${DUMP_DIR}"
+  ls -alh "${DUMP_DIR}"
 
-# Define the variable DUMP_DIR in global
-DUMP_DIR="$PWD/$CLUSTER_ID"
+  return 0
+}
 
 # Function to remove files with Secrets and CERTIFICATE data
 remove_sensitive_files() {
-  cd "$DUMP_DIR"
+  cd "${DUMP_DIR}"
 
   find . -type f -name "*.yaml" -print0 | while IFS= read -r -d '' file; do
-    if yq e '.kind == "Secret"' "$file" &> /dev/null; then
-        echo "Removing $file because it contains a Secret"
-        rm -f "$file"
-    elif yq e '.data[] == "CERTIFICATE"' "$file" &> /dev/null; then
-        echo "Removing $file because it contains CERTIFICATE data"
-        rm -f "$file"
+    if yq e '.kind == "Secret"' "${file}" &> /dev/null; then
+        echo "Removing ${file} because it contains a Secret"
+        rm -f "${file}"
+    elif yq e '.data[] == "CERTIFICATE"' "${file}" &> /dev/null; then
+        echo "Removing ${file} because it contains CERTIFICATE data"
+        rm -f "${file}"
     fi
   done
+
+  return 0
 }
 
 # Function to compress the dump into a tarball
 create_tarball() {
-  cd "$DUMP_DIR"
-  TARBALL_PATH="${DUMP_DIR}/${CLUSTER_ID}_dump.tar.gz"
+  cd "${DUMP_DIR}"
 
-  if [ -f "$TARBALL_PATH" ]; then
-    echo "Tarball $TARBALL_PATH already exists. Exiting."
+  if [ -f "${TARBALL_PATH}" ]; then
+    echo "Tarball ${TARBALL_PATH} already exists. Exiting."
     exit 0
   fi
 
   # Compress the dump directory
-  tar -czvf "$TARBALL_PATH" ./*
+  tar -czvf "${TARBALL_PATH}" ./*
 
-  echo "Compressed hypershift dump is saved as $TARBALL_PATH"
+  echo "Compressed hypershift dump is saved as ${TARBALL_PATH}"
+
+  return 0
 }
 
-# Calling functions to remove the sensitive files and make a compress tarball
+# Function to upload the tarball to SFTP
+upload_tarball() {
+  cd "${DUMP_DIR}"
+
+  # Check if the tarball is in place
+  if [ ! -f "${TARBALL_PATH}" ]; then
+    echo "Tarball is not found in ${TARBALL_PATH}"
+    exit 1
+  fi
+
+  sftp_upload "${TARBALL_PATH}" "${TARBALL_NAME}"
+
+  return 0
+}
+
+# Calling functions to gather must-gather, remove sensitive data and upload.
+collect_must_gather
 remove_sensitive_files
 create_tarball
+upload_tarball
 
 # End
 exit 0


### PR DESCRIPTION
This PR:
- adds a function to upload the compressed tarball to SFTP. `upload_tarball()`  
- wraps the hypershift dump logic into a function. `collect_must_gather()`  
- uses the HostCluster name in `hypershift dump cluster --name`.


Test steps:
- Login to a management cluster.
- Create a testjob with a HCP cluster id.
```
$ ocm-backplane testjob create -p CLUSTER_ID=xxxxxxx
ocm.stg backplane testjob logs openshift-job-dev-clqj9
[long long logs]
Compressed hypershift dump is saved as /root/xxxxxxx
/20230919_xxxxxxx_dump.tar.gz

Uploaded file /root/xxxxxxx/20230919_xxxxxxx_dump.tar.gz to sftp.access.redhat.com, Anonymous username: iMMsiJbN, filename: 20230919_xxxxxxx_dump.tar.gz
For more information about SFTP: https://access.redhat.com/articles/5594481
```