### PR TITLE
Minor improvements over hyperhift must gather script

### DIFF
--- a/scripts/CEE/hs-must-gather/metadata.yaml
+++ b/scripts/CEE/hs-must-gather/metadata.yaml
@@ -99,4 +99,7 @@ envs:
   - key: "CLUSTER_ID"
     description: "Hosted cluster internal ID"
     optional: false
+  - key: "DUMP_GUEST_CLUSTER"
+    description: "Include the guest cluster the must gather"
+    optional: false 
 language: bash

--- a/scripts/lib/sftp_upload/lib.sh
+++ b/scripts/lib/sftp_upload/lib.sh
@@ -40,8 +40,10 @@ function sftp_upload() {
         put $1 $2
         bye
 EOSSHPASS
+    # convert the username to lowercase for ease of copy / paste
+    lower_case_username=$(tr '[:upper:]' '[:lower:]' <<< "${username}")
 
-    echo "Uploaded file $1 to ${FTP_HOST}, Anonymous username: ${username}, filename: $2"
+    echo "Uploaded file $1 to ${FTP_HOST}, Anonymous username: ${lower_case_username}, filename: $2"
     echo "For more information about SFTP: https://access.redhat.com/articles/5594481"
     return 0
 }


### PR DESCRIPTION
This PR adds some minor improvements to the `hs-must-gather` script.

1. Adds a DUMP_GUEST_CLUSTER parameter to optionally include / exclude guest cluster must gather
2. Separates control plane and data plane logs for ease of consumption
3. Renders the SFTP username in lowercase to make it easy to built the SFTP `get` command for download