### PR TITLE
osd-18432: updating python release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN chmod -R +x /out
 
 FROM registry.access.redhat.com/ubi8/ubi:latest
 RUN  yum -y install --disableplugin=subscription-manager \
-     python3 jq openssh-clients sshpass \
+     python3.11 python3.11-pip jq openssh-clients sshpass \
      && yum --disableplugin=subscription-manager clean all
 COPY --from=build-stage0 /out/oc  /usr/local/bin
 COPY --from=build-stage0 /out/oc-hc  /usr/local/bin


### PR DESCRIPTION
Updating Python to release 3.11, and consequently check-jsonschema to 0.26.3.

Installing Python 3.11, it is required to install pip as well.