### PR TITLE
OSD-18414 - Update metadata schema to use clusterVersion

### DIFF
--- a/hack/metadata.schema.json
+++ b/hack/metadata.schema.json
@@ -103,6 +103,15 @@
           }
         }
       }
+    },
+    "clusterVersions": {
+      "type": "array",
+      "description": "List of required cluster versions, supporting 'major.minor.patch' format and wildcards",
+      "additionalProperties": false,
+      "items": {
+        "type": "string",
+        "pattern": "^\\d+\\.\\d+\\.\\d+$|^\\d+\\.\\d+\\.\\*$"
+      }
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
This PR adds the schema update necessary to use clusterVersion validation feature for managed-scripts.

Resolves: [OSD-18414](https://issues.redhat.com//browse/OSD-18414)