### PR TITLE
OSD-19295: Managed Script to Re-run jobs that fail in openshift-sre-pruning namespace

### DIFF
--- a/scripts/SREP/retry-failed-pruning-cronjob/README.md
+++ b/scripts/SREP/retry-failed-pruning-cronjob/README.md
@@ -1,0 +1,13 @@
+# RETRY PRUNING CRON JOB
+
+## Purpose
+
+This script will help re-run the jobs which are failed in `openshift-sre-pruning` namespace
+
+## Usage
+This script will detect and delete the failed jobs that are running in the `openshift-sre-pruning` namespace and causing pruning-cron-job error, deleting will help recreate new jobs and possibly resolve the alert, and if not SREs can investigate and find the root cause.
+
+## Create the ManagedJob to restart the failed jobs
+```
+ocm backplane managedjob create SREP/fix-pruning-cronjob 
+```

--- a/scripts/SREP/retry-failed-pruning-cronjob/metadata.yaml
+++ b/scripts/SREP/retry-failed-pruning-cronjob/metadata.yaml
@@ -1,0 +1,26 @@
+file: script.sh
+name: fix-pruning-cron-job-error
+description: Retry the failed jobs in openshift-sre-pruning namespace
+author: Dee-6777
+allowedGroups:
+  - SREP
+labels:
+  - key: OSD_TYPES
+    description: Compatible cluster types for this script
+    values:
+      - OSD
+rbac:
+    roles:
+      - namespace: "openshift-sre-pruning"
+        rules:
+          - verbs:
+            - "get"
+            - "list"
+            - "watch"
+            - "delete"
+            - "create"
+            apiGroups:
+            - "batch"
+            resources:
+            - "jobs"
+language: bash

--- a/scripts/SREP/retry-failed-pruning-cronjob/script.sh
+++ b/scripts/SREP/retry-failed-pruning-cronjob/script.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Delete and recreate jobs that fail in openshift-sre-pruning namespace and producing prunining cron job error.
+
+set -x
+set -e
+set -o nounset
+set -o pipefail
+
+readonly PRUNING_NS=openshift-sre-pruning
+
+BUILDS_PRUNER=()
+DEPLOYMENTS_PRUNER=()
+FAILED_JOBS=()
+BUILDS_PRUNER_FAILED=()
+DEPLOYMENTS_PRUNER_FAILED=()
+
+BUILDS_PRUNER+=($(oc get jobs -n "$PRUNING_NS" -o=jsonpath='{.items[?(@.metadata.ownerReferences[*].name=="builds-pruner")].metadata.name}'))
+DEPLOYMENTS_PRUNER+=($(oc get jobs -n "$PRUNING_NS" -o=jsonpath='{.items[?(@.metadata.ownerReferences[*].name=="deployments-pruner")].metadata.name}'))
+
+detect_job() {
+  echo "INFO: finding jobs producing error"
+  FAILED_JOBS+=($(oc get jobs -n "$PRUNING_NS" -o=jsonpath='{.items[?(@.status.failed>1)].metadata.name}'))
+}
+
+delete_job() {
+  if [[ ${#FAILED_JOBS[*]} == 0 ]]; then
+    echo "INFO: no failed jobs found exiting.."
+    return 1
+  else
+    echo "INFO: deleting jobs producing error"
+    for jobs in "${FAILED_JOBS[@]}"; do
+      oc delete job "$jobs" -n "$PRUNING_NS"
+    done
+  fi
+}
+
+rerun_job() {
+  for jobs in "${FAILED_JOBS[@]}"; do
+    if [[ ${BUILDS_PRUNER[@]} =~ ${jobs} ]]; then
+      BUILDS_PRUNER_FAILED+=("${jobs}")
+    elif [[ ${DEPLOYMENTS_PRUNER[@]} =~ ${jobs} ]]; then
+      DEPLOYMENTS_PRUNER_FAILED+=("${jobs}")
+    fi  
+  done
+
+  if [[ ${#BUILDS_PRUNER_FAILED[*]} != 0 ]]; then
+    echo "INFO: creating a builds puner job"
+    oc create job --from=cronjob/builds-pruner "${BUILDS_PRUNER_FAILED[0]}" -n "$PRUNING_NS"
+  fi
+
+  if [[ ${#DEPLOYMENTS_PRUNER_FAILED[*]} != 0 ]]; then
+    echo "INFO: creating a deployments puner job"
+    oc create job --from=cronjob/deployments-pruner "${DEPLOYMENTS_PRUNER_FAILED[0]}" -n "$PRUNING_NS"
+  fi
+}
+
+main() {
+  detect_job
+  delete_job
+  rerun_job
+  echo "Succeed."
+  exit 0
+}
+
+main "$@"


### PR DESCRIPTION
This script is for the alert Pruning Cronjob Error. Here it will detect and delete the failed jobs that are running in the `openshift-sre-pruning` namespace and causing this error, deleting will help recreate new jobs and possibly resolve the alert, and if not SREs can start investigating and find the root cause.

