### PR TITLE
Fix Error for Managed Script to Re-run jobs that fail in openshift-sre-pruning namespace

### DIFF
--- a/scripts/SREP/retry-failed-pruning-cronjob/metadata.yaml
+++ b/scripts/SREP/retry-failed-pruning-cronjob/metadata.yaml
@@ -1,5 +1,5 @@
 file: script.sh
-name: fix-pruning-cron-job-error
+name: retry-failed-pruning-cronjob
 description: Retry the failed jobs in openshift-sre-pruning namespace
 author: Dee-6777
 allowedGroups:


### PR DESCRIPTION
A small fix for the managed script `retry-failed-pruning-cronjob`. The name was different from the subdir.