### PR TITLE
Managedscript get-sosreport to collect sosreports for troubleshooting

### DIFF
--- a/scripts/SREP/get-sosreport/README.md
+++ b/scripts/SREP/get-sosreport/README.md
@@ -1,23 +1,14 @@
-# Work In Progress
+# Get SOS Report script
 
-## Layout
+This will script will generate a sosreport, copy to the container volume the push into Red Hat SFTP server.
 
-1. Choose a worker node
-- Set env var $nodename
-- Capture node name through script argument given [WIP]
+- Add the node name as parameter.
+Example:
+```
+ocm backplane managedjob create SREP/get-sosreport -p NODE="ip-10-0-178-83.eu-west-1.compute.internal"
+```
 
-2. Open a debug session with $nodename [DONE]
-- Run chroot /host
-- Run toolbox
-- Run sosreport in non interative mode
-
-3. Capture last compacted file fenerated in `/host/var/tmp` 
-4. Exit debug session [DONE]
-5. Open new debug sesion, and copy the file to inside the backplane managedscript container [DONE]
-6. Copy file to a SFTP server [DONE]
-7. Provide instructions in how to use. [DONE]
-
-## How to pull the collected sosreport from the SFTP Server.
+## How to pull the collected sosreport from Red Hat SFTP Server.
 
 1. Take note of the `Anonymous username` and `filename` from the the job output.
 

--- a/scripts/SREP/get-sosreport/README.md
+++ b/scripts/SREP/get-sosreport/README.md
@@ -4,33 +4,44 @@
 
 1. Choose a worker node
 - Set env var $nodename
-- Capture node name through script argument given
-2. Open a debug session with $nodename
+- Capture node name through script argument given [WIP]
+
+2. Open a debug session with $nodename [DONE]
 - Run chroot /host
 - Run toolbox
 - Run sosreport in non interative mode
 ```bash
 sos report -k crio.all=on -k crio.logs=on --batch
 ```
-3. Capture last compacted file fenerated in `/host/var/tmp`
+3. Capture last compacted file fenerated in `/host/var/tmp` 
 ```
 ls -tA /host/var/tmp/*.tar.xz | head -1
 ```
-4. Exit debug session
-5. Open new debug sesion, and copy the file to inside the backplane managedscript container
+4. Exit debug session [DONE]
+5. Open new debug sesion, and copy the file to inside the backplane managedscript container [DONE]
 ```
 oc debug node/my-cluster-node -- bash -c 'cat /host/var/tmp/sosreport-my-cluster-node-01234567-2020-05-28-eyjknxt.tar.xz' > /tmp/sosreport-my-cluster-node-01234567-2020-05-28-eyjknxt.tar.xz
 ```
 
-6. Copy file to a bucket and extract from there?
+6. Copy file to a SFTP server [DONE]
 
-### Commands
+7. Provide instructions in how to use. [DONE]
 
+## How to pull the collected sosreport from the SFTP Server.
+
+1. Take note of the `Anonymous username` and `filename` from the the job output.
+
+2. Access the [SFTP Token Portal](https://access.redhat.com/sftp-token/#/external).
+- Use your Red Hat username. Eg. (rhn-support-hgomes)
+- Click **Generate Token**
+
+3. Open a local terminal and access SFTP server, as **password** use the generated token from step 2.
 ```
---- Choosing the worker node
-oc get nodes -l node-role.kubernetes.io/worker="" --no-headers | awk '{print $1}' | sed 1q
---- 1st Debug session command
-oc -n default debug node\/"$node" -- sh -c 'chroot /host toolbox sos report -k crio.all=on -k crio.logs=on --batch'
---- 2nd Debug session command
-oc -n default debug node\/"$node" -- bash -c 'cat $(ls -tA /host/var/tmp/*.tar.xz | head -1)' > sosreport.tar.xz ;
+❯ sftp rhn-support-hgomes@sftp.access.redhat.com
+rhn-support-hgomes@sftp.access.redhat.com's password:
+```
+
+4. Using the `anonymous username` and `filename` fetch the file. It will be saved in the local directory.
+```
+sftp> get anonymous/users/yqjqoccq/20231114AM-ip-10-0-178-83.eu-west-1.compute.internal-sosreport.tar.xz
 ```

--- a/scripts/SREP/get-sosreport/README.md
+++ b/scripts/SREP/get-sosreport/README.md
@@ -1,0 +1,36 @@
+# Work In Progress
+
+## Layout
+
+1. Choose a worker node
+- Set env var $nodename
+- Capture node name through script argument given
+2. Open a debug session with $nodename
+- Run chroot /host
+- Run toolbox
+- Run sosreport in non interative mode
+```bash
+sos report -k crio.all=on -k crio.logs=on --batch
+```
+3. Capture last compacted file fenerated in `/host/var/tmp`
+```
+ls -tA /host/var/tmp/*.tar.xz | head -1
+```
+4. Exit debug session
+5. Open new debug sesion, and copy the file to inside the backplane managedscript container
+```
+oc debug node/my-cluster-node -- bash -c 'cat /host/var/tmp/sosreport-my-cluster-node-01234567-2020-05-28-eyjknxt.tar.xz' > /tmp/sosreport-my-cluster-node-01234567-2020-05-28-eyjknxt.tar.xz
+```
+
+6. Copy file to a bucket and extract from there?
+
+### Commands
+
+```
+--- Choosing the worker node
+oc get nodes -l node-role.kubernetes.io/worker="" --no-headers | awk '{print $1}' | sed 1q
+--- 1st Debug session command
+oc -n default debug node\/"$node" -- sh -c 'chroot /host toolbox sos report -k crio.all=on -k crio.logs=on --batch'
+--- 2nd Debug session command
+oc -n default debug node\/"$node" -- bash -c 'cat $(ls -tA /host/var/tmp/*.tar.xz | head -1)' > sosreport.tar.xz ;
+```

--- a/scripts/SREP/get-sosreport/README.md
+++ b/scripts/SREP/get-sosreport/README.md
@@ -10,21 +10,11 @@
 - Run chroot /host
 - Run toolbox
 - Run sosreport in non interative mode
-```bash
-sos report -k crio.all=on -k crio.logs=on --batch
-```
+
 3. Capture last compacted file fenerated in `/host/var/tmp` 
-```
-ls -tA /host/var/tmp/*.tar.xz | head -1
-```
 4. Exit debug session [DONE]
 5. Open new debug sesion, and copy the file to inside the backplane managedscript container [DONE]
-```
-oc debug node/my-cluster-node -- bash -c 'cat /host/var/tmp/sosreport-my-cluster-node-01234567-2020-05-28-eyjknxt.tar.xz' > /tmp/sosreport-my-cluster-node-01234567-2020-05-28-eyjknxt.tar.xz
-```
-
 6. Copy file to a SFTP server [DONE]
-
 7. Provide instructions in how to use. [DONE]
 
 ## How to pull the collected sosreport from the SFTP Server.

--- a/scripts/SREP/get-sosreport/metadata.yaml
+++ b/scripts/SREP/get-sosreport/metadata.yaml
@@ -30,4 +30,8 @@ rbac:
             - ""
           resources:
             - "nodes"
+envs:
+  - key: "NODE"
+    description: "node name"
+    optional: false
 language: bash

--- a/scripts/SREP/get-sosreport/metadata.yaml
+++ b/scripts/SREP/get-sosreport/metadata.yaml
@@ -1,0 +1,33 @@
+file: script.sh
+name: get-sosreport
+description: Collect a sosreport from a specific node
+author: Hevellyn Gomes 
+allowedGroups:
+  - SREP
+  - LPSRE
+  - CEE
+labels:
+  - key: OSD_TYPES
+    description: Compatible cluster types for this script
+    values:
+      - OSD
+rbac:
+    roles:
+      - namespace: "default"
+        rules:
+          - verbs:
+            - "create"
+            - "delete"
+            apiGroups:
+            - ""
+            resources:
+            - "pods"
+    clusterRoleRules:
+        - verbs:
+            - "get"
+            - "list"
+          apiGroups:
+            - ""
+          resources:
+            - "nodes"
+language: bash

--- a/scripts/SREP/get-sosreport/script.sh
+++ b/scripts/SREP/get-sosreport/script.sh
@@ -7,7 +7,7 @@ set -o pipefail
 ## validate input
 if [[ -z "$NODE" ]]
 then
-    echo 'Variable node cannot be blank'
+    echo "Variable node cannot be blank"
     exit 1
 fi
 
@@ -37,21 +37,21 @@ generate_sosreport() {
 # 1st Debug session - Generate the sosreport and keep it in the host
 
     echo " ==== Generating SOSREPORT ===="
-    oc -n default debug node/"${NODE}" -- sh -c 'chroot /host toolbox sos report -k crio.all=on -k crio.logs=on --batch'
+    oc -n default debug node/"${NODE}" -- sh -c "chroot /host toolbox sos report -k crio.all=on -k crio.logs=on --batch"
 
     return 0
 }
 
 validate_file() {
     echo "==== Check if the sosreport is created inside the node ===="
-    oc -n default debug node/"${NODE}" -- bash -c 'ls -l /host/var/tmp/*.tar.xz' | tee;
+    oc -n default debug node/"${NODE}" -- bash -c "ls -l /host/var/tmp/*.tar.xz" | tee;
 
     return 0
 }
 
 copy_sosreport() {
 # 2nd Debug session - Fetch sosreport .tar.xz file and save inside the container volume.
-    oc -n default debug node/"${NODE}" -- bash -c 'cat $(ls -tA /host/var/tmp/sosreport-$HOSTNAME-*.tar.xz | head -1)' > ${DUMP_DIR}/sosreport-${NODE}.tar.xz ;
+    oc -n default debug node/"${NODE}" -- bash -c "cat $(ls -tA /host/var/tmp/sosreport-$HOSTNAME-*.tar.xz | head -1)" > ${DUMP_DIR}/sosreport-${NODE}.tar.xz ;
 
     echo "==== Check if file exists inside container ===="
 
@@ -66,7 +66,7 @@ delete_sosreport_from_node() {
 # Deleting any sosreport from the /host/var/tmp inside node
 
     echo "==== Deleting file from the node ===="
-    oc -n default debug node/"${NODE}" -- sh -c 'rm /host/var/tmp/sosreport-$HOSTNAME-* && ls -l /host/var/tmp/'
+    oc -n default debug node/"${NODE}" -- sh -c "rm /host/var/tmp/sosreport-$HOSTNAME-* && ls -l /host/var/tmp/"
 
     echo "==== SOSREPORT file should be now not showing in the list ===="
 

--- a/scripts/SREP/get-sosreport/script.sh
+++ b/scripts/SREP/get-sosreport/script.sh
@@ -51,7 +51,7 @@ validate_file() {
 
 copy_sosreport() {
 # 2nd Debug session - Fetch sosreport .tar.xz file and save inside the container volume.
-    oc -n default debug node/"${NODE}" -- bash -c "cat $(find /host/var/tmp/sosreport-$HOSTNAME-*.tar.xz | head -1)" > "${DUMP_DIR}"/sosreport-"${NODE}".tar.xz ;
+    oc -n default debug node/"${NODE}" -- bash -c "cat $(find /host/var/tmp/sosreport-"$HOSTNAME"-*.tar.xz | head -1)" > "${DUMP_DIR}"/sosreport-"${NODE}".tar.xz ;
 
     echo "==== Check if file exists inside container ===="
 

--- a/scripts/SREP/get-sosreport/script.sh
+++ b/scripts/SREP/get-sosreport/script.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#set -e
+#set -o nounset
+#set -o pipefail
+
+# Import sftp_upload library
+source /managed-scripts/lib/sftp_upload/lib.sh
+
+# Define expected values
+DUMP_DIR="${PWD}"
+DATE="$(date +"%Y%m%d%p")"
+NODE="ip-10-0-178-83.eu-west-1.compute.internal"
+SOSREPORT_FILENAME="${NODE}-sosreport.tar.xz"
+SOSREPORT_FILEPATH="${DUMP_DIR}/${NODE}-sosreport.tar.xz"
+
+# /host/var/tmp/sosreport-ip-10-0-178-83-2023-11-14-dscgket.tar.xz
+# Mostrar PWD -> pwd == /root
+echo $(pwd)
+
+generate_sosreport() {
+# 1st Debug session - Generate the sosreport and keep it in the host
+
+    echo " ==== Generating SOSREPORT ===="
+    oc -n default debug node/"${NODE}" -- sh -c 'chroot /host toolbox sos report -k crio.all=on -k crio.logs=on --batch'
+
+    return 0
+}
+
+validate_file() {
+    echo "==== Check if the sosreport is created inside the node ===="
+    oc -n default debug node/"${NODE}" -- bash -c 'ls -l /host/var/tmp/*.tar.xz' | tee;
+
+    return 0
+}
+
+copy_sosreport() {
+# 2nd Debug session - Fetch sosreport .tar.xz file and save inside the container volume.
+    oc -n default debug node/"${NODE}" -- bash -c 'cat $(ls -tA /host/var/tmp/*.tar.xz | head -1)' > ${DUMP_DIR}/${NODE}-sosreport.tar.xz ;
+
+    echo "==== Check if file exists inside container ===="
+
+    ls -la ${DUMP_DIR}/${NODE}-sosreport.tar.xz
+
+    return 0
+}
+
+# Function to upload the tarball to SFTP
+upload_sosreport() {
+  cd "${DUMP_DIR}"
+
+  # Check if the tarball is in place
+  if [ ! -f "${SOSREPORT_FILEPATH}" ]; then
+    echo "Sosreport file is not found in ${SOSREPORT_FILEPATH}"
+    exit 1
+  fi
+
+  sftp_upload "${SOSREPORT_FILEPATH}" "${DATE}-${SOSREPORT_FILENAME}"
+
+  return 0
+}
+
+generate_sosreport
+validate_file
+copy_sosreport
+upload_sosreport

--- a/scripts/SREP/get-sosreport/script.sh
+++ b/scripts/SREP/get-sosreport/script.sh
@@ -51,7 +51,7 @@ validate_file() {
 
 copy_sosreport() {
 # 2nd Debug session - Fetch sosreport .tar.xz file and save inside the container volume.
-    oc -n default debug node/"${NODE}" -- bash -c "cat $(find /host/var/tmp/sosreport-"$HOSTNAME"-*.tar.xz | head -1)" > "${DUMP_DIR}"/sosreport-"${NODE}".tar.xz ;
+    oc -n default debug node/"${NODE}" -- bash -c "cat $(find /host/var/tmp/sosreport-$HOSTNAME-*.tar.xz | head -1)" > "${DUMP_DIR}"/sosreport-"${NODE}".tar.xz ;
 
     echo "==== Check if file exists inside container ===="
 
@@ -66,7 +66,7 @@ delete_sosreport_from_node() {
 # Deleting any sosreport from the /host/var/tmp inside node
 
     echo "==== Deleting file from the node ===="
-    oc -n default debug node/"${NODE}" -- sh -c "rm /host/var/tmp/sosreport-"$HOSTNAME"-* && ls -l /host/var/tmp/"
+    oc -n default debug node/"${NODE}" -- sh -c "rm /host/var/tmp/sosreport-$HOSTNAME-* && ls -l /host/var/tmp/"
 
     echo "==== SOSREPORT file should be now not showing in the list ===="
 

--- a/scripts/SREP/get-sosreport/script.sh
+++ b/scripts/SREP/get-sosreport/script.sh
@@ -1,21 +1,37 @@
 #!/bin/bash
-#set -e
-#set -o nounset
-#set -o pipefail
+
+set -e
+set -o nounset
+set -o pipefail
+
+## validate input
+if [[ -z "$NODE" ]]
+then
+    echo 'Variable node cannot be blank'
+    exit 1
+fi
 
 # Import sftp_upload library
 source /managed-scripts/lib/sftp_upload/lib.sh
 
 # Define expected values
 DUMP_DIR="${PWD}"
-DATE="$(date +"%Y%m%d%p")"
-NODE="ip-10-0-178-83.eu-west-1.compute.internal"
-SOSREPORT_FILENAME="${NODE}-sosreport.tar.xz"
-SOSREPORT_FILEPATH="${DUMP_DIR}/${NODE}-sosreport.tar.xz"
+DATE="$(date -u +"%Y%m%dT%H%M")"
+SOSREPORT_FILENAME="sosreport-${NODE}.tar.xz"
+SOSREPORT_FILEPATH="${DUMP_DIR}/sosreport-${NODE}.tar.xz"
 
-# /host/var/tmp/sosreport-ip-10-0-178-83-2023-11-14-dscgket.tar.xz
-# Mostrar PWD -> pwd == /root
-echo $(pwd)
+
+
+check_node(){
+    echo "Checking if \"${NODE}\" is an existing node..."
+    
+    if (oc get nodes -l node-role.kubernetes.io/worker= -oname | grep "${NODE}") &> /dev/null; then
+       echo "[OK] \"${NODE}\" is a node."
+    else
+        echo "[Error] \"${NODE}\" is not a node. Exiting script"
+        exit 1
+    fi
+}
 
 generate_sosreport() {
 # 1st Debug session - Generate the sosreport and keep it in the host
@@ -35,11 +51,24 @@ validate_file() {
 
 copy_sosreport() {
 # 2nd Debug session - Fetch sosreport .tar.xz file and save inside the container volume.
-    oc -n default debug node/"${NODE}" -- bash -c 'cat $(ls -tA /host/var/tmp/*.tar.xz | head -1)' > ${DUMP_DIR}/${NODE}-sosreport.tar.xz ;
+    oc -n default debug node/"${NODE}" -- bash -c 'cat $(ls -tA /host/var/tmp/sosreport-$HOSTNAME-*.tar.xz | head -1)' > ${DUMP_DIR}/sosreport-${NODE}.tar.xz ;
 
     echo "==== Check if file exists inside container ===="
 
-    ls -la ${DUMP_DIR}/${NODE}-sosreport.tar.xz
+    ls -la ${DUMP_DIR}/sosreport-${NODE}.tar.xz
+
+    echo "======================="
+
+    return 0
+}
+
+delete_sosreport_from_node() {
+# Deleting any sosreport from the /host/var/tmp inside node
+
+    echo "==== Deleting file from the node ===="
+    oc -n default debug node/"${NODE}" -- sh -c 'rm /host/var/tmp/sosreport-$HOSTNAME-* && ls -l /host/var/tmp/'
+
+    echo "==== SOSREPORT file should be now not showing in the list ===="
 
     return 0
 }
@@ -59,7 +88,9 @@ upload_sosreport() {
   return 0
 }
 
+check_node
 generate_sosreport
 validate_file
 copy_sosreport
+delete_sosreport_from_node
 upload_sosreport

--- a/scripts/SREP/get-sosreport/script.sh
+++ b/scripts/SREP/get-sosreport/script.sh
@@ -51,7 +51,7 @@ validate_file() {
 
 copy_sosreport() {
 # 2nd Debug session - Fetch sosreport .tar.xz file and save inside the container volume.
-    oc -n default debug node/"${NODE}" -- bash -c "cat $(ls -tA /host/var/tmp/sosreport-$HOSTNAME-*.tar.xz | head -1)" > "${DUMP_DIR}"/sosreport-"${NODE}".tar.xz ;
+    oc -n default debug node/"${NODE}" -- bash -c "cat $(find /host/var/tmp/sosreport-"$HOSTNAME"-*.tar.xz | head -1)" > "${DUMP_DIR}"/sosreport-"${NODE}".tar.xz ;
 
     echo "==== Check if file exists inside container ===="
 
@@ -66,7 +66,7 @@ delete_sosreport_from_node() {
 # Deleting any sosreport from the /host/var/tmp inside node
 
     echo "==== Deleting file from the node ===="
-    oc -n default debug node/"${NODE}" -- sh -c "rm /host/var/tmp/sosreport-$HOSTNAME-* && ls -l /host/var/tmp/"
+    oc -n default debug node/"${NODE}" -- sh -c "rm /host/var/tmp/sosreport-"$HOSTNAME"-* && ls -l /host/var/tmp/"
 
     echo "==== SOSREPORT file should be now not showing in the list ===="
 

--- a/scripts/SREP/get-sosreport/script.sh
+++ b/scripts/SREP/get-sosreport/script.sh
@@ -25,7 +25,7 @@ SOSREPORT_FILEPATH="${DUMP_DIR}/sosreport-${NODE}.tar.xz"
 check_node(){
     echo "Checking if \"${NODE}\" is an existing node..."
     
-    if (oc get nodes -l node-role.kubernetes.io/worker= -oname | grep "${NODE}") &> /dev/null; then
+    if (oc get nodes --no-headers -oname | grep "${NODE}") &> /dev/null; then
        echo "[OK] \"${NODE}\" is a node."
     else
         echo "[Error] \"${NODE}\" is not a node. Exiting script"

--- a/scripts/SREP/get-sosreport/script.sh
+++ b/scripts/SREP/get-sosreport/script.sh
@@ -51,11 +51,11 @@ validate_file() {
 
 copy_sosreport() {
 # 2nd Debug session - Fetch sosreport .tar.xz file and save inside the container volume.
-    oc -n default debug node/"${NODE}" -- bash -c "cat $(ls -tA /host/var/tmp/sosreport-$HOSTNAME-*.tar.xz | head -1)" > ${DUMP_DIR}/sosreport-${NODE}.tar.xz ;
+    oc -n default debug node/"${NODE}" -- bash -c "cat $(ls -tA /host/var/tmp/sosreport-$HOSTNAME-*.tar.xz | head -1)" > "${DUMP_DIR}"/sosreport-"${NODE}".tar.xz ;
 
     echo "==== Check if file exists inside container ===="
 
-    ls -la ${DUMP_DIR}/sosreport-${NODE}.tar.xz
+    ls -la "${DUMP_DIR}"/sosreport-"${NODE}".tar.xz
 
     echo "======================="
 


### PR DESCRIPTION
This script was written in order to suffice the need of capturing an sosreport proactively from nodes when required node-level troubleshooting and/or to assist in pursuit of RCA's when required.