### PR TITLE
Restructure Failed job command

### DIFF
--- a/scripts/SREP/retry-failed-pruning-cronjob/README.md
+++ b/scripts/SREP/retry-failed-pruning-cronjob/README.md
@@ -9,5 +9,5 @@ This script will detect and delete the failed jobs that are running in the `open
 
 ## Create the ManagedJob to restart the failed jobs
 ```
-ocm backplane managedjob create SREP/fix-pruning-cronjob 
+ocm backplane managedjob create SREP/retry-failed-pruning-cronjob 
 ```


### PR DESCRIPTION
Failed job command is restructured which will help detect jobs that are failed because the pod takes forever to complete.