### PR TITLE
Update from deprecated get-token command

### DIFF
--- a/scripts/CEE/list-alerts/script.sh
+++ b/scripts/CEE/list-alerts/script.sh
@@ -112,7 +112,7 @@ function list_alerts(){
     for host in "${!hostarray[@]}" ; do
 	    echo "Retrieving alerts from the ${hostarray[$host]} Prometheus instance in the ${host} namespace:"
 	    PROM_HOST=$(_get_host ${host} ${hostarray[$host]})
-	    PROM_TOKEN=$(oc -n ${host} sa get-token ${hostarray[$host]})
+	    PROM_TOKEN=$(oc -n ${host} create token ${hostarray[$host]} --duration 10m)
 	    # The alertmanager route name differs for each namespace, so we need to retrieve it dynamically
 	    AM_HOST=$(_get_host "${host}" "$(oc get routes -n ${host} -o custom-columns=NAME:.metadata.name | grep alertmanager)")
 


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / Why we need it?
The `get-token` command is deprecated as an SA token for the prometheus-k8s service account may not exist.

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR