### PR TITLE
OSD-19605 a script to extract email from pull secret

### DIFF
--- a/scripts/SREP/get-pull-secret-email/README.md
+++ b/scripts/SREP/get-pull-secret-email/README.md
@@ -1,0 +1,12 @@
+# Get Pull Secret Email
+
+## Purpose
+
+This script will output the email address of the `cloud.openshift.com` registry authentication info in the pull secret.
+
+This script allows the users to validate the email without exposing the authentication tokens. 
+
+## Usage
+```
+ocm backplane managedjob create SREP/get-pull-secret-email 
+```

--- a/scripts/SREP/get-pull-secret-email/metadata.yaml
+++ b/scripts/SREP/get-pull-secret-email/metadata.yaml
@@ -1,0 +1,25 @@
+file: script.sh
+name: get-pull-secret-email
+description: Get the email of the pull-secret in the cluster.
+author: feichashao
+allowedGroups:
+  - SREP
+  - CEE
+  - LPSRE
+labels:
+  - key: OSD_TYPES
+    description: Compatible cluster types for this script
+    values:
+      - OSD
+      - HyperShift
+rbac:
+    roles:
+      - namespace: "openshift-config"
+        rules:
+          - verbs:
+            - "get"
+            apiGroups:
+            - ""
+            resources:
+            - "secrets"
+language: bash

--- a/scripts/SREP/get-pull-secret-email/script.sh
+++ b/scripts/SREP/get-pull-secret-email/script.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+
+oc get secret pull-secret -n openshift-config -o json | jq -r '."data".".dockerconfigjson"' | base64 -d | jq -r '."auths"."cloud.openshift.com"."email"'
+
+exit 0


### PR DESCRIPTION
### What type of PR is this?

Feature

### What this PR does / Why we need it?
In some cases, SRE need to validate if the email in the pull secret matches the record in OCM.
Instead of pulling down the how secret file, we can use this script to only get the info needed for validation.

### Which Jira/Github issue(s) does this PR fix?
Part of [OSD-19605](https://issues.redhat.com//browse/OSD-19605)

### Special notes for your reviewer
The test result looks like this:
```
ocm backplane testjob logs openshift-job-dev-wnrbj 
siwu@redhat.com
```
It can be run on both classic OSD and Hypershift clusters.

### Pre-checks (if applicable)

- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR