### PR TITLE
WIP: Run managed-scripts as non root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,4 +127,6 @@ RUN aws --version
 
 # Cleanup Home Dir
 RUN rm /root/anaconda* /root/original-ks.cfg
-WORKDIR /root
+
+USER 1001
+WORKDIR /managed-scripts

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ isclean:
 
 .PHONY: build
 build: isclean validation shellcheck pyflakes
-	$(CONTAINER_ENGINE) build -t $(IMAGE_URI_VERSION) .
+	$(CONTAINER_ENGINE) build --platform=linux/amd64 -t $(IMAGE_URI_VERSION) .
 	$(CONTAINER_ENGINE) tag $(IMAGE_URI_VERSION) $(IMAGE_URI_LATEST)
 
 .PHONY: validation
@@ -30,13 +30,13 @@ validation:
 
 .PHONY: shellcheck
 shellcheck:
-	$(CONTAINER_ENGINE) pull $(SHELL_CHECK_IMAGE)
-	$(CONTAINER_ENGINE) run -v $(shell pwd):/app --entrypoint=/bin/sh -w=/app/scripts $(SHELL_CHECK_IMAGE) -c "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && yum install -y ShellCheck && find . -name '*.sh' -print0 | xargs -0 -n1 shellcheck -e SC2154 "
+	$(CONTAINER_ENGINE) pull --platform=linux/amd64 $(SHELL_CHECK_IMAGE)
+	$(CONTAINER_ENGINE) run --platform=linux/amd64 -v $(shell pwd):/app --entrypoint=/bin/sh -w=/app/scripts $(SHELL_CHECK_IMAGE) -c "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && yum install -y ShellCheck && find . -name '*.sh' -print0 | xargs -0 -n1 shellcheck -e SC2154 "
 
 .PHONY: pyflakes
 pyflakes:
-	$(CONTAINER_ENGINE) pull $(PYTHON_IMAGE)
-	$(CONTAINER_ENGINE) run -v $(shell pwd):/app --entrypoint=/bin/sh -w=/app/scripts $(PYTHON_IMAGE) -c "pip3 install pyflakes && find . -name '*.py' -print0 | xargs -0 -n1 pyflakes "
+	$(CONTAINER_ENGINE) pull --platform=linux/amd64 $(PYTHON_IMAGE)
+	$(CONTAINER_ENGINE) run --platform=linux/amd64 -v $(shell pwd):/app --entrypoint=/bin/sh -w=/app/scripts $(PYTHON_IMAGE) -c "pip3 install pyflakes && find . -name '*.py' -print0 | xargs -0 -n1 pyflakes "
 
 .PHONY: push
 push:


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Managed scripts are failing to run after the pod was configured to `runAsNonRoot: true`

```
104s        Normal    AddedInterface   pod/openshift-job-phjwv   Add eth0 [10.129.3.169/23] from openshift-sdn
13s         Normal    Pulled           pod/openshift-job-phjwv   Container image "quay.io/app-sre/managed-scripts:dc9134c" already present on machine
13s         Warning   Failed           pod/openshift-job-phjwv   Error: container has runAsNonRoot and image will run as root (pod: "openshift-job-phjwv_openshift-backplane-managed-scripts(0796b2ba-6db1-4066-af20-6b1fd2160fde)", container: job)
```

### Pre-checks (if applicable)

- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR