### PR TITLE
OSD-19604: Script to automate infranode resize without elevation

### DIFF
--- a/scripts/SREP/infra-node-resize/README.md
+++ b/scripts/SREP/infra-node-resize/README.md
@@ -1,0 +1,16 @@
+# INFRA NODE RESIZE
+
+## Purpose
+
+This script will help automate infra node resize without having the need to elevate access permissions.
+
+## Usage
+To use this script you will need to first login to a Hive shard.
+This script runs on a production Hive shard and helps resize the infra nodes of the cluster to the desired size. Meaning, SREs do not have to elevate permissions to perform this operation.
+
+## Create the ManagedJob to resize infra-nodes
+```
+ocm backplane login <hive_shard>
+
+ocm backplane managedjob create SREP/infra-node-resize -p CLUSTER_ID=<Internal CLUSTER_ID> -p INSTANCE_SIZE=<desired instance size>
+```

--- a/scripts/SREP/infra-node-resize/metadata.yaml
+++ b/scripts/SREP/infra-node-resize/metadata.yaml
@@ -1,0 +1,28 @@
+file: script.sh
+name: infra-node-resize
+description: Resize infra node without elevation.
+author: dee-6777
+allowedGroups: 
+  - SREP
+rbac:
+    clusterRoleRules:
+        - verbs:
+            - "get"
+            - "list"
+            - "watch"
+            - "create"
+            - "delete"
+            - "patch"
+          apiGroups:
+            - "hive.openshift.io"
+          resources:
+            - "machinepools"
+            - "machinepools/scale"
+envs:
+  - key: "CLUSTER_ID"
+    description: "requires internal cluster ID"
+    optional: false
+  - key: "INSTANCE_SIZE"
+    description: "desired size"
+    optional: false
+language: bash

--- a/scripts/SREP/infra-node-resize/script.sh
+++ b/scripts/SREP/infra-node-resize/script.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# This script checks if any tech preview features are enabled through feature sets.
+
+set -e
+set -o nounset
+set -o pipefail
+
+# fetch the infra machinepools
+get_machinepool() {
+    echo 'FETCHING INFRA MACHINEPOOLS...'
+    NAMESPACE=$(oc get ns | grep "$CLUSTER_ID" | awk '{print $1}')
+    oc -n "$NAMESPACE" get machinepool
+    INFRA_MACHINEPOOL=$(oc -n "$NAMESPACE"  get machinepool -o json | jq -r '.items[] | select(.spec.name=="infra") | .metadata.name')
+    oc -n "$NAMESPACE" get machinepool "$INFRA_MACHINEPOOL" -o json | jq -r ".spec.platform.type"
+}
+
+# update the yaml file
+update_cluster_infra_yaml() {
+    echo 'UPDATING THE YAML FILE FOR TEMPORARY MACHINEPOOL...'
+    oc -n "$NAMESPACE" get machinepool "$INFRA_MACHINEPOOL" -o yaml > /tmp/cluster-infra.yaml
+    yq -i 'del(.metadata.creationTimestamp) | del(.metadata.finalizer) | del(.metadata.resourceVersion) | del(.metadata.generation) | del(.metadata.selfLink) | del(.metadata.uid) | del(.status)' /tmp/cluster-infra.yaml
+    cat /tmp/cluster-infra.yaml 
+    CLOUD=$(oc -n "$NAMESPACE" get machinepool "$INFRA_MACHINEPOOL" -o json | jq -r '.spec.platform | keys_unsorted[0]')
+    yq -i ".metadata.name |= . + 2 | .spec.name |= . + 2 | .spec.platform.$CLOUD.type |= env(INSTANCE_SIZE)" /tmp/cluster-infra.yaml 
+}
+
+# create the temporary machinepool
+create_temp_machinepool() {
+    echo 'CREATING TEMPORARY MACHINEPOOL...'
+    oc -n "$NAMESPACE" create -f /tmp/cluster-infra.yaml
+    while [[ ! -z "$(oc get machinepool -n "$NAMESPACE" "$INFRA_MACHINEPOOL" -o=jsonpath='{.status.machineSets[0].errorMessage}')" ]];
+    do
+        echo 'MACHINES ARE STILL NOT CORRECTLY PROVISIONED...'
+        timeout 10
+    done
+    oc -n "$NAMESPACE" get machinepool
+}
+
+# delete the original machinepool
+delete_original_machinepool() {
+    echo 'DELETING THE ORIGINAL MACHINEPOOL...'
+    oc scale --replicas 0 machinepool "$INFRA_MACHINEPOOL" -n "$NAMESPACE"
+    oc -n "$NAMESPACE" get machinepool
+    while [[ ! -z "$(oc get machinepool -n "$NAMESPACE" "$INFRA_MACHINEPOOL" -o=jsonpath='{.status.machineSets[0].errorMessage}')" ]];
+    do
+        echo 'MACHINES ARE STILL NOT PROPERL DELETED...'
+        timeout 10
+    done
+    oc -n "$NAMESPACE" delete machinepool "$INFRA_MACHINEPOOL"
+    echo 'ORIGINAL MACHINEPOOLS WHICH ARE NOT RESIZED ARE DELETED...'
+    oc -n "$NAMESPACE" get machinepool
+}
+
+# update yaml file cluster 
+update_new_infra_yaml() {
+    echo 'UPDATING YAML FILE...'
+    yq eval '.metadata.name |= sub("2$"; "") | .spec.name |= sub("2$"; "")' -i /tmp/cluster-infra.yaml 
+    cat /tmp/cluster-infra.yaml
+}
+
+# create new machinepool
+create_new_machinepool() {
+    echo 'CREATING NEW MACHINEPOOL...'
+    oc -n "$NAMESPACE" create -f /tmp/cluster-infra.yaml
+    while [[ ! -z "$(oc get machinepool -n "$NAMESPACE" "$INFRA_MACHINEPOOL" -o=jsonpath='{.status.machineSets[0].errorMessage}')" ]];
+    do
+        echo 'MACHINES ARE STILL NOT CORRECTLY PROVISIONED...'
+        timeout 10
+    done
+}
+
+# delete temporary machinepool 
+delete_temp_machinepool() {
+    echo 'DELETING TEMPORARY MACHINEPOOL...'
+    oc scale --replicas 0 machinepool "${INFRA_MACHINEPOOL}"2 -n "$NAMESPACE"
+    oc -n "$NAMESPACE" get machinepool
+    while [[ ! -z "$(oc get machinepool -n "$NAMESPACE" "$INFRA_MACHINEPOOL" -o=jsonpath='{.status.machineSets[0].errorMessage}')" ]];
+    do
+        echo 'MACHINES ARE STILL NOT PROPERLY DELETED...'
+        timeout 10
+    done
+    oc -n "$NAMESPACE" delete machinepool "${INFRA_MACHINEPOOL}"2 
+    echo 'TEMPORARY MACHINEPOOLS ARE DELETED...'
+}
+
+# check the state of machinepools
+verify_machinepools() {
+    echo 'VERIFYING MACHINEPOOLS...'
+    echo 'FETCHING MACHINEPOOL NAME..'
+    INFRA_MACHINEPOOL_NAME=$(oc -n "$NAMESPACE"  get machinepool -o json | jq -r '.items[] | select(.spec.name=="infra") | .metadata.name')
+    echo "THIS INFRA MACHINEPOOL HAS BEEN RESIZED $INFRA_MACHINEPOOL_NAME"
+    INFRA_MACHINEPOOL_SIZE=$(oc -n "$NAMESPACE" get machinepool "$INFRA_MACHINEPOOL" -o=jsonpath="{.spec.platform.$CLOUD.type}")
+    echo 'CHECKING IF IT HAS BEEN RESIZED CORRECTLY..'
+    if [[ "$INFRA_MACHINEPOOL_SIZE" == "$INSTANCE_SIZE" ]]; then
+        echo 'INFRA RESIZE HAS BEEN SUCCESSFULLY DONE..'
+    else
+        echo 'INFRA RESIZE UNSUCCESSFUL..'
+    fi
+}
+
+main() {
+  get_machinepool
+  update_cluster_infra_yaml
+  create_temp_machinepool
+  delete_original_machinepool
+  update_new_infra_yaml
+  create_new_machinepool
+  delete_temp_machinepool
+  verify_machinepools
+  echo "Succeed."
+  exit 0
+}
+
+main "$@"


### PR DESCRIPTION
### What type of PR is this?

_feature_

### What this PR does / Why we need it?
It will help automate infra-node resize and without any elevation. SRE just needs to pass the Internal Cluster ID, hive name and the desired instance size.

### Which Jira/Github issue(s) does this PR fix?

_Resolves_ #[OSD-19604](https://issues.redhat.com/browse/OSD-19604)

### Special notes for your reviewer
This script runs in hive, so to test it in a staging cluster you need to create a hive namespace, install the hive operator, and then add the machinepools.

### Pre-checks (if applicable)

- [X] Validated the changes in a cluster
- [X] Included documentation changes with PR