### PR TITLE
Feat/retrieve pdbs

### DIFF
--- a/scripts/CEE/retrieve-pdbs/README.md
+++ b/scripts/CEE/retrieve-pdbs/README.md
@@ -1,0 +1,64 @@
+# Retrieve PDBs Script
+
+## Purpose
+
+This script is designed to retrieve information about Pod Disruption Budgets (PDBs) in OpenShift clusters. It provides details about PDBs in OpenShift namespaces, with options to retrieve information from specific namespaces, all namespaces, or only namespaces with restrictive PDBs.
+
+## Parameters and Usage
+
+### Usage
+
+```bash
+namespace variable options:
+    - Empty/not declared:      Retrieves PDBs from all openshift* namespaces
+    - --all:                   Retrieves PDBs from all namespaces
+    - --restrictive:           Retrieves restrictive PDBs from all namespaces
+    - <ns1>,<ns2>...:          Desired namespaces, separated by comma, to retrieve the PDBs
+```
+
+### Options
+
+If you want to retrieve PDBs from specific namespaces, provide the namespace variable as a comma-separated list:
+```bash
+namespace=<namespace1>,<namespace2>,... ./script.sh
+```
+
+To retrieve PDBs from all namespaces in the cluster, use the --all option:
+```bash
+namespace=--all ./script.sh
+```
+
+To retrieve only restrictive PDBs from all namespaces in the cluster, use the --restrictive option:
+```bash
+namespace=--restrictive ./script.sh
+```
+
+
+
+
+
+
+
+
+
+
+### Usage with managed-scripts
+
+For usage with managed-scripts, the options need to be passed through the `namespace` environment variable.
+Some examples are:
+
+```bash
+ocm backplane managedjob create CEE/retrieve-pdbs
+
+ocm backplane managedjob create CEE/retrieve-pdbs -p namespace="namespace1,namespace2"
+
+ocm backplane managedjob create CEE/retrieve-pdbs -p namespace="--all"
+
+ocm backplane managedjob create CEE/retrieve-pdbs -p namespace="--restrictive"
+```
+
+## Important Notes
+
+- The script uses the `oc` command-line tool, and the user running the script should have the necessary permissions to access the cluster.
+- This script is read-only and does not modify any resources in the cluster.
+- Ensure that the required tools (`oc` & `jq`) are available in the environment where the script is executed.

--- a/scripts/CEE/retrieve-pdbs/metadata.yaml
+++ b/scripts/CEE/retrieve-pdbs/metadata.yaml
@@ -1,0 +1,30 @@
+file: script.sh
+name: retrieve-pdb
+description: Retrieve PDBs from namespaces
+author: Daniel Fernandez
+allowedGroups:
+  - CEE
+  - SREP
+rbac:
+  clusterRoleRules:
+    - verbs:
+        - get
+        - list
+      apiGroups:
+        - ''
+      resources:
+        - namespaces
+    - verbs:
+        - get
+        - list
+      apiGroups:
+        - "policy"
+      resources:
+        - poddisruptionbudgets
+
+envs:
+  - key: namespace
+    description: namespace/s where to retrieve and display the PDBs
+    optional: true
+
+language: bash

--- a/scripts/CEE/retrieve-pdbs/script.sh
+++ b/scripts/CEE/retrieve-pdbs/script.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+set -o pipefail
+
+# Function to retrieve all namespaces starting with openshift
+get_openshift_namespaces() {
+    oc get namespaces -o json | jq -r '.items[].metadata.name' | grep '^openshift'
+}
+
+# Function to retrieve and display PDBs for a given namespace
+get_and_display_pdbs() {
+    local namespace="$1"
+    echo "---------------------------------"
+    echo "PDBs in namespace: $namespace"
+    echo ""
+    oc get poddisruptionbudget -n "$namespace"
+}
+
+# Check if the 'namespace' variable is provided
+if [ -z "${namespace:-}" ]; then
+    echo "No 'namespace' provided. Retrieving PDBs from all openshift namespaces."
+    openshift_namespaces=( $(get_openshift_namespaces) )
+
+    # Loop through each openshift namespace and display PDBs
+    for namespace in "${openshift_namespaces[@]}"; do
+        echo ""
+        get_and_display_pdbs "$namespace"
+    done
+
+elif [ "${namespace}" = "--all" ]; then
+    echo "Retrieving PDBs from all namespaces in the cluster."
+    for namespace in $(oc get namespaces -o jsonpath='{.items[*].metadata.name}'); do
+        echo ""
+        get_and_display_pdbs "$namespace"
+    done
+
+elif [ "${namespace}" = "--restrictive" ]; then
+    echo "Checking for restrictive PDBs in all namespaces in the cluster."
+
+    restrictive_found=false
+
+    for namespace in $(oc get namespaces -o jsonpath='{.items[*].metadata.name}'); do
+        echo ""
+        restrictive_pdbs=$(oc get poddisruptionbudget -n "$namespace" -o json | jq -r '.items[] | select(.spec.maxUnavailable == 0 or .spec.maxUnavailable == "0%") | "\(.metadata.name)\t-->\tmaxUnavailable: \(.spec.maxUnavailable)"')
+
+        if [ -n "${restrictive_pdbs}" ]; then
+            echo "---------------------------------"
+            echo "Restrictive PDBs found in namespace: $namespace"
+            echo "${restrictive_pdbs}"
+            restrictive_found=true
+        else
+            echo "---------------------------------"
+            echo "No restrictive PDBs found in namespace: $namespace"
+        fi
+    done
+
+    if [ "${restrictive_found}" = false ]; then
+        echo ""
+        echo "---------------------------------"
+        echo "No restrictive PDBs found in any namespace."
+    fi
+
+else
+    echo "Using provided 'namespace' variable: ${namespace}"
+    # Split the 'namespace' variable into an array using ',' as the delimiter
+    IFS=',' read -ra namespaces <<< "${namespace}"
+    NAMESPACE_DEFAULT="${namespaces[@]}"
+
+    # Loop through each provided namespace and display PDBs
+    for namespace in "${namespaces[@]}"; do
+        echo ""
+        get_and_display_pdbs "$namespace"
+    done
+fi

--- a/scripts/CEE/retrieve-pdbs/script.sh
+++ b/scripts/CEE/retrieve-pdbs/script.sh
@@ -66,7 +66,9 @@ else
     echo "Using provided 'namespace' variable: ${namespace}"
     # Split the 'namespace' variable into an array using ',' as the delimiter
     IFS=',' read -ra namespaces <<< "${namespace}"
-    NAMESPACE_DEFAULT="${namespaces[@]}"
+    # To avoid the SC2034
+    export NAMESPACE_DEFAULT=""
+    NAMESPACE_DEFAULT="${namespaces[*]}"
 
     # Loop through each provided namespace and display PDBs
     for namespace in "${namespaces[@]}"; do


### PR DESCRIPTION
### What type of PR is this?

Feature

### What does this PR do / Why do we need it?

This PR introduces a script to review the deployed PodDisruptionBudgets (PDBs) across cluster namespaces.
It includes a "restrictive" option to retrieve only the restrictive PDBs in all namespaces.

### Which Jira/Github issue(s) does this PR fix?

N/A

### Special notes for your reviewer

This script is a part of the Cluster Health Check steps.

### Pre-checks (if applicable)

- [X] Validated the changes in a cluster
- [X] Included documentation and examples
