### PR TITLE
Fixed broken link for google styles

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -19,4 +19,4 @@ This guide provides in broad strokes a set of Bash best practices that are expec
 
 ### Good references
 
-- Google's Bash styleguide [http://google-styleguide.googlecode.com/svn/trunk/shell.xml](http://google-styleguide.googlecode.com/svn/trunk/shell.xml)
+- Google's Bash styleguide [https://google.github.io/styleguide/shellguide.html](https://google.github.io/styleguide/shellguide.html)


### PR DESCRIPTION
### What type of PR is this?

_(cleanup)_

### What this PR does / Why we need it?

The link to google bash styleguide is broken. I replaced http://google-styleguide.googlecode.com/svn/trunk/shell.xml with https://google.github.io/styleguide/shellguide.html