### PR TITLE
Managed Script for "Restart default dns pods in openshift-dns namespace"

### DIFF
--- a/scripts/CEE/restart-dns-default/README.md
+++ b/scripts/CEE/restart-dns-default/README.md
@@ -1,0 +1,14 @@
+# Restart default dns pods in openshift-dns namespace
+
+## Desctiption
+ 
+This cript will trigger a rollout of deamonset, controlling dns default pods. Such action might be required when a customer is not able to perform it themself due to not having enough permissions etc, but dns-default pods need to be restarted.  
+
+## Usage
+
+```bash
+ocm backplane managedjob create CEE/restart-dns-default -p NAMESPACE=openshift-dns
+```
+
+
+

--- a/scripts/CEE/restart-dns-default/README.md
+++ b/scripts/CEE/restart-dns-default/README.md
@@ -2,7 +2,7 @@
 
 ## Desctiption
  
-This script will trigger a rollout of deamonset, controlling dns default pods. Such action might be required when a customer is not able to perform it themself due to not having enough permissions etc, but dns-default pods need to be restarted.  
+This script will trigger a rollout of daemonset, controlling dns default pods. Such action might be required when a customer is not able to perform it themself due to not having enough permissions etc, but dns-default pods need to be restarted.  
 
 ## Usage
 

--- a/scripts/CEE/restart-dns-default/README.md
+++ b/scripts/CEE/restart-dns-default/README.md
@@ -7,7 +7,7 @@ This script will trigger a rollout of daemonset, controlling dns default pods. S
 ## Usage
 
 ```bash
-ocm backplane managedjob create CEE/restart-dns-default -p NAMESPACE=openshift-dns
+ocm backplane managedjob create CEE/restart-dns-default
 ```
 
 

--- a/scripts/CEE/restart-dns-default/README.md
+++ b/scripts/CEE/restart-dns-default/README.md
@@ -2,7 +2,7 @@
 
 ## Desctiption
  
-This cript will trigger a rollout of deamonset, controlling dns default pods. Such action might be required when a customer is not able to perform it themself due to not having enough permissions etc, but dns-default pods need to be restarted.  
+This script will trigger a rollout of deamonset, controlling dns default pods. Such action might be required when a customer is not able to perform it themself due to not having enough permissions etc, but dns-default pods need to be restarted.  
 
 ## Usage
 

--- a/scripts/CEE/restart-dns-default/metadata.yaml
+++ b/scripts/CEE/restart-dns-default/metadata.yaml
@@ -1,0 +1,27 @@
+file: script.sh
+name: restart-dns-default
+description: Restart dns pods in openshift-dns namespace
+author: Yuri Diakov
+allowedGroups:
+  - SREP
+  - LPSRE
+  - CEE
+rbac:
+ roles:
+   - namespace: "openshift-dns"
+     rules:
+       - verbs:
+         - "get"
+         - "patch"
+         - "list"
+         - "watch"
+         apiGroups:
+         - "apps"
+         resources:
+         - "daemonsets"
+         - "pods"
+envs:          
+  - key: NAMESPACE
+    description: The openshift-dns namespace 
+    optional: false
+language: bash

--- a/scripts/CEE/restart-dns-default/metadata.yaml
+++ b/scripts/CEE/restart-dns-default/metadata.yaml
@@ -20,8 +20,4 @@ rbac:
          resources:
          - "daemonsets"
          - "pods"
-envs:          
-  - key: NAMESPACE
-    description: The openshift-dns namespace 
-    optional: false
 language: bash

--- a/scripts/CEE/restart-dns-default/script.sh
+++ b/scripts/CEE/restart-dns-default/script.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -e
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CURRENTDATE=$(date +"%Y-%m-%d %T")
+
+## validate input
+if [[ -z "${NAMESPACE}" ]]; then
+    echo "Variable NAMESPACE cannot be blank"
+    exit 1
+fi
+
+start_job(){
+    echo "Job started at $CURRENTDATE"
+    echo ".................................."
+    echo
+}
+
+finish_job(){
+    echo
+    echo ".................................."
+    echo "Job finished at $CURRENTDATE"
+}
+
+
+
+## Function for daemonsent rollout start
+restart_dns_pods(){
+
+    echo -e "\nRestarting dns_pods in \"${NAMESPACE}\" namespace. Wait until rollout reaches 5 out 5"
+    
+     if oc -n openshift-dns rollout restart ds/dns-default 
+     then
+        echo -e "\n[SUCCESS] Pods rollout started in \"${NAMESPACE}\" ."
+     else
+        echo -e "\n[Error] Pods rollout has failed."
+        exit 1
+     fi
+
+}
+
+
+## Function for daemonset rollout status
+monitor_dns_pods_restar_progress(){
+
+    echo -e "\nRestarting dns_pods in \"${NAMESPACE}\"..."
+
+    if   oc -n openshift-dns rollout status ds/dns-default 
+    then
+        echo -e "\n[SUCCESS] Pods rollout is completed successfully in \"${NAMESPACE}\" namespace.\n"
+       
+    else
+        echo -e "\n[Error] Pods rollout has failed."
+        exit 1
+    fi
+
+}
+
+verify_dns_pods_are_ready(){
+
+echo -e "\nVerifying that pods are in Running state..."
+
+sleep 30
+
+if [[ $(oc wait pods -n openshift-dns -l dns.operator.openshift.io/daemonset-dns=default --for=condition=Ready) ]]; then
+        
+        sleep 30	
+	echo -e "\nAll pods are in the Running state\n";
+	oc get pods -n openshift-dns -l dns.operator.openshift.io/daemonset-dns=default
+	exit 1
+fi
+
+
+}
+
+
+main(){
+    start_job
+    restart_dns_pods
+    monitor_dns_pods_restar_progress
+    verify_dns_pods_are_ready
+    finish_job
+}
+
+main


### PR DESCRIPTION
### What type of PR is this?

This script will trigger a rollout of daemonset, controlling dns default pods. Such action might be required when a customer is not able to perform it themself due to not having enough permissions etc, but dns-default pods need to be restarted.  

### What this PR does / Why we need it?

We have a use case scenarios where a customer is required to restart dns default e.g. after applying a dns forwarding (if this script is considered as a valid then it can be applied to apiserver etc which will reduce the number of requests for SRE) pods and can't do it to multiple reasons (e. g. not having enough permissions, not being able to log in or not having enough expertise). Having this script will let MCS to perform this on behalf of the customer. This script will be run by the CRU member only.

