### PR TITLE
Delete service account in the default namespace

### DIFF
--- a/scripts/CEE/delete-service-account/README.md
+++ b/scripts/CEE/delete-service-account/README.md
@@ -1,0 +1,11 @@
+# Delete a service account in the default namespace
+
+## Purpose 
+This script will remove a service account that was deployed in the default namespace as a part of custom workload. The service account needs to be passed as an argument SERVICE_ACCOUNT
+
+### Usage
+```
+ocm backplane managedjob create CEE/delete-service-account -p SERVICE_ACCOUNT=service_account_name
+```
+
+

--- a/scripts/CEE/delete-service-account/metadata.yaml
+++ b/scripts/CEE/delete-service-account/metadata.yaml
@@ -1,0 +1,26 @@
+file: script.sh
+name: delete-service-account
+description: Delete a service account in the default namespace
+author: Yuri Diakov
+allowedGroups:
+  - SREP
+  - LPSRE
+  - CEE
+rbac:
+ roles:
+   - namespace: "default"
+     rules:
+       - verbs:
+         - "get"
+         - "delete"
+         - "list"
+         - "watch"
+         apiGroups:
+         - ""
+         resources:
+         - "serviceaccounts"
+envs:
+  - key: SERVICE_ACCOUNT
+    description: The service account name
+    optional: false
+language: bash

--- a/scripts/CEE/delete-service-account/script.sh
+++ b/scripts/CEE/delete-service-account/script.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+set -o pipefail
+
+CURRENTDATE=$(date +"%Y-%m-%d %T")
+
+if [[ -z "${SERVICE_ACCOUNT}" ]]; then
+    echo "Variable SERVICE_ACCOUNT cannot be blank"
+    exit 1
+fi
+
+start_job(){
+    echo "Job started at $CURRENTDATE"
+    echo ".................................."
+    echo
+}
+
+finish_job(){
+    echo
+    echo ".................................."
+    echo "Job finished at $CURRENTDATE"
+}
+
+
+## Get info about existing service accounts
+get_existing_sa(){
+
+    echo -e "\nVerifying all existing service accounts in the default namespace\n"
+    oc get sa -n default
+}
+
+## Delete required service account
+
+delete_sa(){
+
+echo -e "\nChecking if service account \"${SERVICE_ACCOUNT}\" exists in the default namespace\n"
+
+    if (oc get sa -n default -o name | grep "${SERVICE_ACCOUNT}") &> /dev/null; then
+        echo -e "[OK] \"${SERVICE_ACCOUNT}\" is present and can be deleted. Proceeding with delition...\n"
+
+        oc delete sa/"${SERVICE_ACCOUNT}" -n default
+
+        echo -e "\nVerifying all remaining service accounts\n"
+
+        oc get sa -n default
+
+    else
+        echo "[Error] service account \"${SERVICE_ACCOUNT}\" is not present. Exiting script..."
+        exit 1
+    fi
+
+
+}
+
+main(){
+    start_job
+    get_existing_sa
+    delete_sa
+    finish_job
+}
+
+main


### PR DESCRIPTION
What type of PR is this?

This script will remove a service account that was deployed in the default namespace as a part of custom workload. The service account needs to be passed as an argument SERVICE_ACCOUNT

From time to time we have such requests and having this script will lower the load to SRE to look into such tasks.

What this PR does / Why we need it?

https://issues.redhat.com/browse/OHSS-34289

Pre-checks (if applicable)

All check have been done in staging and shellcheck used to check script itself