### PR TITLE
egressIP script ready

### DIFF
--- a/scripts/CEE/get-egressip/README.md
+++ b/scripts/CEE/get-egressip/README.md
@@ -1,0 +1,11 @@
+# Get EgressIP details
+
+## Purpose
+This script is designed to retrieve egressIP object, it's config file and nodes that are labelled to participate in IP allocation.
+
+### Usage
+```
+ocm backplane managedjob create CEE/get-egressip
+```
+
+

--- a/scripts/CEE/get-egressip/metadata.yaml
+++ b/scripts/CEE/get-egressip/metadata.yaml
@@ -1,0 +1,19 @@
+file: script.sh
+name: get-egressip
+description: Retrieve config and status of egressip object
+author: Yuri Diakov
+allowedGroups:
+  - CEE
+  - SREP
+rbac:
+  clusterRoleRules:
+    - verbs:
+        - get
+        - list
+      apiGroups:
+        - 'k8s.ovn.org'
+        - ''
+      resources:
+        - egressips
+        - nodes
+language: bash

--- a/scripts/CEE/get-egressip/script.sh
+++ b/scripts/CEE/get-egressip/script.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo -e "Checking egressIP status\n"
+
+oc get egressIP
+
+echo "============================================================"
+echo -e "\nGetting the egressIP config file\n"
+
+oc get egressIP -o yaml
+
+echo "============================================================"
+echo -e "\nChecking nodes with the egress-assignable label\n"
+
+oc get nodes -l k8s.ovn.org/egress-assignable
+
+exit 0


### PR DESCRIPTION
### What type of PR is this?

This script is designed to retrieve egressIP object, it's config file and nodes that are labelled to participate in IP allocation.


### What this PR does / Why we need it?

CEE doesn't have access to view egressIP object using backplane 

`oc get egressip

Error from server (Forbidden): egressips.k8s.ovn.org is forbidden: User "system:serviceaccount:openshift-backplane-cee:8d5ec3a2bb1e28f30a0c48a9eeb707f3" cannot list resource "egressips" in API group "k8s.ovn.org" at the cluster scope`

Having this script will make a troubleshooting process quicker and easier. 

### Which Jira/Github issue(s) does this PR fix?

SFDC case reference number 03801863

### Special notes for your reviewer

### Pre-checks (if applicable)

- script  is checked using shellcheck 
- script is tested in staging 