### PR TITLE
Use specific UBI version, and update yq version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest AS build-stage0
+FROM registry.access.redhat.com/ubi8/ubi:8.9 AS build-stage0
 ARG OC_VERSION="stable"
 ENV OC_URL="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OC_VERSION}"
 
@@ -46,8 +46,8 @@ RUN tar xzf oc-hc-v0.1.3-linux-amd64.tar.gz --directory /out
 
 
 ### Attach yq binary into the image
-ENV YQ_URL="https://github.com/mikefarah/yq/releases/download/v4.35.1/yq_linux_amd64.tar.gz"
-ENV YQ_MD5="be32a02446da244ebe5b94c3834b2c97"
+ENV YQ_URL="https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd64.tar.gz"
+ENV YQ_MD5="7e8bff5d0342f0090e866825cc75d2fc"
 RUN mkdir -p /yq
 WORKDIR /yq
 
@@ -104,7 +104,7 @@ RUN OUT_DIR=/out make hypershift
 # Make binaries executable
 RUN chmod -R +x /out
 
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi8/ubi:8.9
 RUN  yum -y install --disableplugin=subscription-manager \
      python3.11 python3.11-pip jq openssh-clients sshpass \
      && yum --disableplugin=subscription-manager clean all

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMAGE_VERSION=$(shell git rev-parse --short=7 HEAD)
 IMAGE_URI=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME)
 IMAGE_URI_VERSION=$(IMAGE_URI):$(IMAGE_VERSION)
 IMAGE_URI_LATEST=$(IMAGE_URI):latest
-SHELL_CHECK_IMAGE="registry.access.redhat.com/ubi7/ubi:latest"
+SHELL_CHECK_IMAGE="registry.access.redhat.com/ubi8/ubi:8.9"
 PYTHON_IMAGE="registry.access.redhat.com/ubi8/python-36:latest"
 
 CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)


### PR DESCRIPTION
### What type of PR is this?
Version bumps to UBI and yq

### What this PR does / Why we need it?
Pins UBI to a specific version instead of using latest, and updates the yq version to get the latest CVE patches. 

### Which Jira/Github issue(s) does this PR fix?

https://issues.redhat.com/browse/OSD-22358

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR