### PR TITLE
Adding script files to collect and filter cluster autoscaler logs

### DIFF
--- a/scripts/CEE/collect-verbose-ca-logs/README.md
+++ b/scripts/CEE/collect-verbose-ca-logs/README.md
@@ -1,0 +1,24 @@
+# Collect verbose logs from cluster-autoscaler pod
+
+## Description
+
+This script is responsible for collecting verbose logs (logVerbosity=6) from cluster-autoscaler pods
+
+## Steps It Takes
+
+1. The script checks the current verbosity of "default" cluster autoscaler and stores it in a variable
+2. Updates the value for logVerbosity to 6
+3. Collects the verbose logs for 6 minutes
+4. Filters the collected logs by node-names and displays the filtered logs.
+5. Reverts the value of logVerbosity.
+
+## Usage
+
+**ATTENTION** ⚠️ This script must only be used by the MCS (Managed Cloud Services) CRU (Crew Response Unit) team.
+- If you need this script to be used, contact a MCS CRU member.
+- The usage of this script is audited.
+
+```bash
+ocm backplane managedjob create CEE/collect-verbose-ca-logs"
+```
+

--- a/scripts/CEE/collect-verbose-ca-logs/metadata.yaml
+++ b/scripts/CEE/collect-verbose-ca-logs/metadata.yaml
@@ -1,0 +1,42 @@
+file: script.sh
+name: collect-verbose-ca-logs
+description: Script responsible for collecting verbose logs from cluster-autoscaler
+author: Kushagra Kulshreshtha
+allowedGroups:
+  - CEE
+  - SREP
+rbac:
+  roles:
+    - namespace: "openshift-machine-api"
+      rules:
+        - verbs:
+          - "get"
+          - "logs"
+          apiGroups:
+          - "clusterautoscaler.autoscaling.openshift.io"
+          resources:
+          - "pods"
+          - "pods/attach"
+  clusterRoleRules:
+      - verbs:
+        - "get"
+        - "patch"
+        apiGroups:
+        - "autoscaling.openshift.io"
+        resources:
+        - "clusterautoscalers"
+      - verbs:
+        - "get"
+        - "list"
+        apiGroups:
+        - "metrics.k8s.io"
+        resources:
+        - "nodes"
+      - verbs:
+        - "get"
+        - "list"
+        apiGroups:
+        - ''
+        resources:
+        - "nodes"
+language: bash

--- a/scripts/CEE/collect-verbose-ca-logs/script.sh
+++ b/scripts/CEE/collect-verbose-ca-logs/script.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Set variables
+GREEN="\033[32m"
+RESET="\033[0m"
+NAMESPACE="openshift-machine-api"
+CA_NAME="default"
+
+# Get current logVerbosity value
+current_log_verbosity=$(oc get ca $CA_NAME -o jsonpath='{.spec.logVerbosity}')
+
+# Check if current_log_verbosity is empty
+if [ -z "$current_log_verbosity" ]; then
+  echo "Failed to retrieve current logVerbosity value."
+  exit 1
+fi
+
+echo
+echo "CURRENT LOG VERBOSITY = $current_log_verbosity"
+echo
+
+# Update logVerbosity to 6
+oc patch ca $CA_NAME --type='json' -p='[{"op": "replace", "path": "/spec/logVerbosity", "value": 6}]'
+
+updated_log_verbosity=$(oc get ca $CA_NAME -o jsonpath='{.spec.logVerbosity}')
+echo
+echo "UPDATED LOG VERBOSITY = $updated_log_verbosity"
+echo
+
+# Wait for the update to take effect
+echo "Waiting for the log verbosity to update..."
+sleep 30
+
+# Get the name of the Cluster Autoscaler pod
+CA_POD=$(oc get pods -n openshift-machine-api | grep cluster-autoscaler-default | awk '{print $1}')
+
+# Collect logs for the next 6 minutes
+echo
+echo "Collecting logs for the next 6 minutes..."
+echo
+
+sleep 360
+
+echo "---------------------"
+echo "LOG COLLECTION: START"
+echo "---------------------"
+echo
+CA_LOGS=$(oc logs -n $NAMESPACE $CA_POD --since=6m)
+
+#Collect the list of nodes from the cluster
+node_names=$(oc get nodes -o jsonpath='{.items[*].metadata.name}')
+
+for node in $node_names; 
+do
+    echo -e "${GREEN}Searching for node: $node ${RESET}"
+    # Step 3: Display all the log lines where the node name is present
+    echo "$CA_LOGS" | grep "$node"
+    echo
+done
+
+echo
+echo "---------------------"
+echo "LOG COLLECTION: END"
+echo "---------------------"
+
+echo
+
+# Revert logVerbosity to previous value
+oc patch ca $CA_NAME --type='json' -p="[{'op': 'replace', 'path': '/spec/logVerbosity', 'value': $current_log_verbosity}]"
+
+# Wait for the update to take effect
+echo
+echo "Waiting for the log verbosity to be reverted back..."
+echo
+
+sleep 30
+
+current_log_verbosity=$(oc get ca $CA_NAME -o jsonpath='{.spec.logVerbosity}')
+echo "REVERTED LOG VERBOSITY = $current_log_verbosity"
+echo

--- a/scripts/CEE/collect-verbose-ca-logs/script.sh
+++ b/scripts/CEE/collect-verbose-ca-logs/script.sh
@@ -45,7 +45,7 @@ echo "---------------------"
 echo "LOG COLLECTION: START"
 echo "---------------------"
 echo
-CA_LOGS=$(oc logs -n $NAMESPACE $CA_POD --since=6m)
+CA_LOGS=$(oc logs -n $NAMESPACE "$CA_POD" --since=6m)
 
 #Collect the list of nodes from the cluster
 node_names=$(oc get nodes -o jsonpath='{.items[*].metadata.name}')


### PR DESCRIPTION
### What type of PR is this?
A feature addition for MCS team that will enable them to collect and filter verbose cluster autoscaler logs.

### What this PR does / Why we need it?
The script will be responsible for collection and filtering verbose logs from cluster autoscaler pod. We get a lot of cases where the customer reports issues with autoscaling nodes in the cluster (for ex: underutilized nodes are not scaling down). With current logs verbosity, it is not possible to find out the exact reason for why the nodes were not scaling down/up. On the other hand, setting permanent high value for logVerbosity aggressively uses the  storage. The script will update the verbosity, collect the verbose logs for 6 minutes and reset the logVerbosity value. The script will also filter the collected based on node names. 

Additionally, we will be using this script to completely automated troubleshooting for cluster autoscaling cases using our CLI troubleshooting tool inceptor.  

### Which Jira/Github issue(s) does this PR fix?
https://issues.redhat.com/browse/OSD-22869