### PR TITLE
add :Z mount to fix local validation errors when using podman

### DIFF
--- a/hack/schema_validation.sh
+++ b/hack/schema_validation.sh
@@ -61,7 +61,7 @@ yamlList() {
 check_validation() {
 
   echo "validating the jsonschema for $yamlFiles"
-  $CONTAINER_ENGINE run --rm -v $(pwd):$CONTAINER_PATH quay.io/app-sre/managed-scripts:latest /root/.local/bin/check-jsonschema --schemafile $CONTAINER_PATH/hack/metadata.schema.json $yamlFiles
+  $CONTAINER_ENGINE run --rm -v $(pwd):$CONTAINER_PATH:Z quay.io/app-sre/managed-scripts:latest /root/.local/bin/check-jsonschema --schemafile $CONTAINER_PATH/hack/metadata.schema.json $yamlFiles
 
 }
 


### PR DESCRIPTION
not sure if this is the right approach but when calling `make validation ` using podman I get permissions errors. 