### PR TITLE
OSD-24608 : fixed docker file build issue and SElinux container execute issues 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi:8.9 AS build-stage0
 
-ARG OC_VERSION="stable"
+ARG OC_VERSION="stable-4.15"
 ENV OC_URL="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OC_VERSION}"
 
 # AWS cli args and env variables

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ validation:
 .PHONY: shellcheck
 shellcheck:
 	$(CONTAINER_ENGINE) pull $(SHELL_CHECK_IMAGE)
-	$(CONTAINER_ENGINE) run -v $(shell pwd):/app --entrypoint=/bin/sh -w=/app/scripts $(SHELL_CHECK_IMAGE) -c "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && yum install -y ShellCheck && find . -name '*.sh' -print0 | xargs -0 -n1 shellcheck -e SC2154 "
+	$(CONTAINER_ENGINE) run --security-opt label=disable -v $(shell pwd):/app --entrypoint=/bin/sh -w=/app/scripts $(SHELL_CHECK_IMAGE) -c "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && yum install -y ShellCheck && find . -name '*.sh' -print0 | xargs -0 -n1 shellcheck -e SC2154 "
 
 .PHONY: pyflakes
 pyflakes:

--- a/hack/schema_validation.sh
+++ b/hack/schema_validation.sh
@@ -61,7 +61,7 @@ yamlList() {
 check_validation() {
 
   echo "validating the jsonschema for $yamlFiles"
-  $CONTAINER_ENGINE run --rm -v $(pwd):$CONTAINER_PATH quay.io/app-sre/managed-scripts:latest /root/.local/bin/check-jsonschema --schemafile $CONTAINER_PATH/hack/metadata.schema.json $yamlFiles
+  $CONTAINER_ENGINE run --rm --security-opt label=disable -v $(pwd):$CONTAINER_PATH:rw  quay.io/app-sre/managed-scripts:latest /root/.local/bin/check-jsonschema --schemafile $CONTAINER_PATH/hack/metadata.schema.json $yamlFiles
 
 }
 


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?
Docker build throws the following errors. 
```
oc: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by oc)
```

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_
https://issues.redhat.com/browse/OSD-24608

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR