### PR TITLE
[OSD-24941] Update make file to use EPEL8 and fix all the shell check errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ validation:
 .PHONY: shellcheck
 shellcheck:
 	$(CONTAINER_ENGINE) pull $(SHELL_CHECK_IMAGE)
-	$(CONTAINER_ENGINE) run --security-opt label=disable -v $(shell pwd):/app --entrypoint=/bin/sh -w=/app/scripts $(SHELL_CHECK_IMAGE) -c "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && yum install -y ShellCheck && find . -name '*.sh' -print0 | xargs -0 -n1 shellcheck -e SC2154 "
+	$(CONTAINER_ENGINE) run --security-opt label=disable -v $(shell pwd):/app --entrypoint=/bin/sh -w=/app/scripts $(SHELL_CHECK_IMAGE) -c "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && yum install -y ShellCheck && find . -name '*.sh' -print0 | xargs -0 -n1 shellcheck -e SC2154 "
 
 .PHONY: pyflakes
 pyflakes:

--- a/scripts/CEE/check-tech-preview-features/README.md
+++ b/scripts/CEE/check-tech-preview-features/README.md
@@ -1,9 +1,9 @@
 # Check Tech Preview Features
 
 ## Description
-This scripts is used to check if the cluster has any tech preview features enabled.
+This script is used to check if the cluster has any tech preview features enabled.
 
-It checks for any feature sets in the cluster, if found then it lists the feature set along with the feature gates enabled additonally apart from the default enabled feature gates.
+It checks for any feature sets in the cluster, if found then it lists the feature set along with the feature gates enabled additionally apart from the default enabled feature gates.
 
 ## Terminology
 - **Feature Set**:  A feature set is a collection of OpenShift Container Platform features that are not enabled by default.

--- a/scripts/CEE/check-tech-preview-features/script.sh
+++ b/scripts/CEE/check-tech-preview-features/script.sh
@@ -23,7 +23,7 @@ getFeatureGates() {
 }
 
 getAdditionalFeatureGates() {
-arg=(${1})
+IFS=' ' read -r -a arg <<< "${1}"
 for i in "${arg[@]}"
 	do
 		if [[ ! ${DEFAULT_FEATURE_GATES[*]}  =~ ${i} ]]; then

--- a/scripts/CEE/get-events/script.sh
+++ b/scripts/CEE/get-events/script.sh
@@ -21,7 +21,7 @@ get_and_display_events() {
 # Check if the 'namespace' variable is provided
 if [ -z "${namespace:-}" ]; then
     echo "No 'namespace' provided. Retrieving events from all openshift namespaces."
-    openshift_namespaces=( $(get_openshift_namespaces) )
+    IFS=' ' read -r -a openshift_namespaces <<< "${get_openshift_namespaces}"
 
     # Loop through each openshift namespace and display events
     for namespace in "${openshift_namespaces[@]}"; do

--- a/scripts/CEE/hs-must-gather/script.sh
+++ b/scripts/CEE/hs-must-gather/script.sh
@@ -4,6 +4,7 @@ set -e
 set -o nounset
 set -o pipefail
 
+# shellcheck source=/dev/null
 source /managed-scripts/lib/sftp_upload/lib.sh
 
 # Define expected values

--- a/scripts/CEE/kubelet-restart/script.sh
+++ b/scripts/CEE/kubelet-restart/script.sh
@@ -24,28 +24,17 @@ finish_job(){
     echo "Job finished at $CURRENTDATE"
 }
 
-
-
 ## Function for kubelet restart
 restart_kubelet(){
-
     echo "Restarting Kubelet on \"${NODE}\"..."
-    cat <<EOF | oc -n default debug node/${NODE}
-    chroot /host 
-    systemctl restart kubelet
-EOF
-
-    if [ $? -eq 0 ]; then 
-        echo "[SUCCESS] Kubelet successfully restarted on \"${NODE}\" ."
+    if oc -n default debug node/"${NODE}" -- chroot /host systemctl restart kubelet; then
+        echo "[SUCCESS] Kubelet successfully restarted on \"${NODE}\"."
         echo
     else
         echo "[Error] Something is fishy."
         exit 1
     fi
-
 }
-
-
 
 main(){
     start_job

--- a/scripts/CEE/list-alerts/script.sh
+++ b/scripts/CEE/list-alerts/script.sh
@@ -31,7 +31,7 @@ done
 # Sets the types of alerts to retrieve (warning, critical, firing-only, pending, all-states)
 function set_alert_list(){
 	# List of alert states
-	ALERT_OPTIONS_ARRAY=($SCRIPT_PARAMETERS)
+	IFS=' ' read -r -a ALERT_OPTIONS_ARRAY <<< "$SCRIPT_PARAMETERS"
 
 	for ARG in "${ALERT_OPTIONS_ARRAY[@]}" ; do
 		if [ "$ARG" == "--warning-only" ] ; then

--- a/scripts/CEE/worker-node-operations/script.sh
+++ b/scripts/CEE/worker-node-operations/script.sh
@@ -90,28 +90,37 @@ drain_worker(){
         echo "Draining node ${WORKER} for rebooting."
         echo
         IFS=' ' read -r -a drainparams <<< "${1}"
-        ${DRAIN_CMD} "${drainparams[@]}"
+        if ${DRAIN_CMD} "${drainparams[@]}"; then
+            echo "[OK] Node ${WORKER} drained successfully."
+            exit 0
+        else
+            echo "[Error] Something went wrong."
+            exit 1
+        fi
     
     else
     
         if ! declare -p DRAINMODE &>/dev/null || [ -z "${DRAINMODE}" ]; then
             echo "Draining node ${WORKER} with no options."
-            echo
-            ${DRAIN_CMD}
+            if ${DRAIN_CMD} ; then
+                echo "[OK] Node ${WORKER} drained successfully."
+                exit 0
+            else
+                echo "[Error] Something went wrong."
+                exit 1
+            fi
         else
             echo "Draining node ${WORKER} with drain mode '${DRAINMODE}'"
             echo
             IFS=' ' read -r -a drainparams <<< "${DRAINMODE}"
-            ${DRAIN_CMD} "${drainparams[@]}"
+            if ${DRAIN_CMD} "${drainparams[@]}"; then
+                echo "[OK] Node ${WORKER} drained successfully."
+                exit 0
+            else
+                echo "[Error] Something went wrong."
+                exit 1
+            fi
         fi
-    fi
-
-    if [ $? -eq 0 ]; then 
-        echo "[OK] Node ${WORKER} drained successfully."
-        echo
-    else
-        echo "[Error] Something went wrong."
-        exit 1
     fi
 
 }
@@ -123,8 +132,8 @@ reboot_worker(){
 
     drain_worker "${FORCEDRAINMODE}"
 
-    echo "Rebooting node ${WORKER}..."
-    cat <<EOF | oc -n default debug node/$WORKER
+    echo "Rebooting node \"${WORKER}\"..."
+    cat <<EOF | oc -n default debug node/"$WORKER"
     chroot /host
     reboot
 EOF

--- a/scripts/SREP/describe-nodes/metadata.yaml
+++ b/scripts/SREP/describe-nodes/metadata.yaml
@@ -23,7 +23,6 @@ rbac:
 envs:
   - key: "SCRIPT_PARAMETERS"
     description: "Parameters to be passed to the script. You can set the variable to '--help' to get list of supported parameters"
-    optional: true
 language: bash
 labels:
   - key: OSD_TYPES
@@ -31,5 +30,6 @@ labels:
     values:
       - OSD
       - HyperShift
+    optional: true
 customerDataAccess: true
       

--- a/scripts/SREP/describe-nodes/script.sh
+++ b/scripts/SREP/describe-nodes/script.sh
@@ -66,7 +66,7 @@ if [ -z "${SCRIPT_PARAMETERS+x}" ]
 then
   error-out "The 'SCRIPT_PARAMETERS' argument has not been provided: via Backplane script parameter; Or via export if running on the command line"
 fi
-ARG_ARRAY=( ${SCRIPT_PARAMETERS} )
+IFS=' ' read -r -a ARG_ARRAY <<< "${SCRIPT_PARAMETERS}"
 while [[ ${#ARG_ARRAY[@]} -gt 0 ]]
 do
   case "${ARG_ARRAY[0]}" in
@@ -94,52 +94,38 @@ do
       ARG_ARRAY=("${ARG_ARRAY[@]:1}")  # shift past argument
       ;;
     -n|--node|--nodes)
-      if [ -n "${nodes}" ]
-      then
+      if [ -n "${nodes}" ]; then
         error-out "Only 1 '--nodes' argument can be provided"
       fi
       # Check for unset or empty arguments and values that look like a flag/switch
-      if [ ${#ARG_ARRAY[@]} -le 1 ] \
-        || [ -z "${ARG_ARRAY[1]}" ] \
-        || [[ "${ARG_ARRAY[1]}" =~ ^-.* ]]
-      then
+      if [ ${#ARG_ARRAY[@]} -le 1 ] || [ -z "${ARG_ARRAY[1]}" ] || [[ "${ARG_ARRAY[1]}" =~ ^-.* ]]; then
         error-out "The '--nodes' argument requires a list of nodes to be provided"
       fi
       # Check for illegal characters in the list of nodes
       badChars="$(echo "${ARG_ARRAY[1]}" | tr -d '[:alnum:]' | tr -d '-' | tr -d '.' | tr -d ',')"
-      if [ -n "${badChars}" ]
-      then  
+      if [ -n "${badChars}" ]; then
         error-out "The '--nodes' argument can only contain '.|-|,|<alphaNumeric>' characters.  These characters '${badChars}' are illegal"
       fi
       nodes="${ARG_ARRAY[1]}"
       ARG_ARRAY=("${ARG_ARRAY[@]:2}")  # shift past argument and value
       ;;
     -l|--selector)
-      if [ -n "${selector}" ] # retest
-      then
+      if [ -n "${selector}" ]; then
         error-out "Only 1 '--selector' argument can be provided"
       fi
       # Check for unset or empty arguments and values that look like a flag/switch
-      if [ ${#ARG_ARRAY[@]} -le 1 ] \
-        || [ -z "${ARG_ARRAY[1]}" ] \
-        || [[ "${ARG_ARRAY[1]}" =~ ^-.* ]]
-      then
+      if [ ${#ARG_ARRAY[@]} -le 1 ] || [ -z "${ARG_ARRAY[1]}" ] || [[ "${ARG_ARRAY[1]}" =~ ^-.* ]]; then
         error-out "The '--selector' argument must contain a node selector"
       fi
-      badChars="$(echo "${ARG_ARRAY[1]}" | tr -d '[:alnum:]' | tr -d '-' | tr -d '.'  | tr -d '/'  \
-          | tr -d ',' | tr -d ':' | tr -d ' ' | tr -d '(' | tr -d ')' | tr -d '!' | tr -d '=')"
-      if [ -n "${badChars}" ] # retest
-      then
+      badChars="$(echo "${ARG_ARRAY[1]}" | tr -d '[:alnum:]' | tr -d '-' | tr -d '.'  | tr -d '/' | tr -d ',' | tr -d ':' | tr -d ' ' | tr -d '(' | tr -d ')' | tr -d '!' | tr -d '=')"
+      if [ -n "${badChars}" ]; then
         error-out "The '--selector' argument must not contain illegal characters.  These characters '${badChars}' are illegal"
       fi
       selector="${ARG_ARRAY[1]}"
       ARG_ARRAY=("${ARG_ARRAY[@]:2}")  # shift past argument and value
       ;;
-    -*|--*)
-      error-out "Unknown option '${ARG_ARRAY[0]}'"
-      ;;
     *)
-      error-out "Unknown argument"
+      error-out "Unknown option or argument '${ARG_ARRAY[0]}'"
       ;;
   esac
 done

--- a/scripts/SREP/infra-node-resize/script.sh
+++ b/scripts/SREP/infra-node-resize/script.sh
@@ -28,7 +28,7 @@ update_cluster_infra_yaml() {
 create_temp_machinepool() {
     echo 'CREATING TEMPORARY MACHINEPOOL...'
     oc -n "$NAMESPACE" create -f /tmp/cluster-infra.yaml
-    while [[ ! -z "$(oc get machinepool -n "$NAMESPACE" "$INFRA_MACHINEPOOL" -o=jsonpath='{.status.machineSets[0].errorMessage}')" ]];
+    while [[ -n "$(oc get machinepool -n "$NAMESPACE" "$INFRA_MACHINEPOOL" -o=jsonpath='{.status.machineSets[0].errorMessage}')" ]];
     do
         echo 'MACHINES ARE STILL NOT CORRECTLY PROVISIONED...'
         timeout 10
@@ -41,7 +41,7 @@ delete_original_machinepool() {
     echo 'DELETING THE ORIGINAL MACHINEPOOL...'
     oc scale --replicas 0 machinepool "$INFRA_MACHINEPOOL" -n "$NAMESPACE"
     oc -n "$NAMESPACE" get machinepool
-    while [[ ! -z "$(oc get machinepool -n "$NAMESPACE" "$INFRA_MACHINEPOOL" -o=jsonpath='{.status.machineSets[0].errorMessage}')" ]];
+    while [[ -n "$(oc get machinepool -n "$NAMESPACE" "$INFRA_MACHINEPOOL" -o=jsonpath='{.status.machineSets[0].errorMessage}')" ]];
     do
         echo 'MACHINES ARE STILL NOT PROPERL DELETED...'
         timeout 10
@@ -62,7 +62,7 @@ update_new_infra_yaml() {
 create_new_machinepool() {
     echo 'CREATING NEW MACHINEPOOL...'
     oc -n "$NAMESPACE" create -f /tmp/cluster-infra.yaml
-    while [[ ! -z "$(oc get machinepool -n "$NAMESPACE" "$INFRA_MACHINEPOOL" -o=jsonpath='{.status.machineSets[0].errorMessage}')" ]];
+    while [[ -n "$(oc get machinepool -n "$NAMESPACE" "$INFRA_MACHINEPOOL" -o=jsonpath='{.status.machineSets[0].errorMessage}')" ]];
     do
         echo 'MACHINES ARE STILL NOT CORRECTLY PROVISIONED...'
         timeout 10
@@ -74,7 +74,7 @@ delete_temp_machinepool() {
     echo 'DELETING TEMPORARY MACHINEPOOL...'
     oc scale --replicas 0 machinepool "${INFRA_MACHINEPOOL}"2 -n "$NAMESPACE"
     oc -n "$NAMESPACE" get machinepool
-    while [[ ! -z "$(oc get machinepool -n "$NAMESPACE" "$INFRA_MACHINEPOOL" -o=jsonpath='{.status.machineSets[0].errorMessage}')" ]];
+    while [[ -n "$(oc get machinepool -n "$NAMESPACE" "$INFRA_MACHINEPOOL" -o=jsonpath='{.status.machineSets[0].errorMessage}')" ]];
     do
         echo 'MACHINES ARE STILL NOT PROPERLY DELETED...'
         timeout 10

--- a/scripts/SREP/mg-log-extractor/script.sh
+++ b/scripts/SREP/mg-log-extractor/script.sh
@@ -13,43 +13,43 @@ if [ -z "$hiveconfig" ] ; then
 fi
 
 bucket=$(echo "$hiveconfig" | jq -r '.spec.failedProvisionConfig.aws.bucket')
-if [ -z "$bucket" -o "$bucket" == "null" ] ; then
+if [ -z "$bucket" ] || [ "$bucket" == "null" ] ; then
   echo "Error: Unable to determine S3 bucket from hiveconfig."
   exit 10
 fi
 
 region=$(echo "$hiveconfig" | jq -r '.spec.failedProvisionConfig.aws.region')
-if [ -z "$region" -o "$region" == "null" ] ; then
+if [ -z "$region" ] || [ "$region" == "null" ] ; then
   echo "Error: Unable to determine AWS region from hiveconfig."
   exit 10
 fi
 
 secret_name=$(echo "$hiveconfig" | jq -r '.spec.failedProvisionConfig.aws.credentialsSecretRef.name')
-if [ -z "$secret_name" -o "$secret_name" == "null" ] ; then
+if [ -z "$secret_name" ] || [ "$secret_name" == "null" ] ; then
   echo "Error: Unable to determine AWS credentials secret name from hiveconfig."
   exit 10
 fi
 
 credentials_secret=$(oc get secret -n hive -o json "$secret_name")
-if [ -z "$credentials_secret" -o "$credentials_secret" == "null" ] ; then
+if [ -z "$credentials_secret" ] || [ "$credentials_secret" == "null" ] ; then
   echo "Error: Unable to retrieve credentials secret [$secret_name]."
   exit 10
 fi
 
 AWS_ACCESS_KEY_ID=$(echo "$credentials_secret" | jq -r '.data.aws_access_key_id' | base64 -d)
-if [ -z "$AWS_ACCESS_KEY_ID" -o "$AWS_ACCESS_KEY_ID" == "null" ] || [[ "$AWS_ACCESS_KEY_ID" != AKIA* ]] ; then
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ "$AWS_ACCESS_KEY_ID" == "null" ] || [[ "$AWS_ACCESS_KEY_ID" != AKIA* ]] ; then
   echo "Error: Unable to retrieve aws_access_key_id from secret [$secret_name] in the hive namespace."
   exit 10
 fi
 
 AWS_SECRET_ACCESS_KEY=$(echo "$credentials_secret" | jq -r '.data.aws_secret_access_key' | base64 -d)
-if [ -z "$AWS_SECRET_ACCESS_KEY" -o "$AWS_SECRET_ACCESS_KEY" == "null" ]; then
+if [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ "$AWS_SECRET_ACCESS_KEY" == "null" ]; then
   echo "Error: Unable to retrieve aws_secret_access_key from secret [$secret_name] in the hive namespace."
   exit 10
 fi
 
 s3_log_dir="$TARGET_LOG_DIR"
-if [ -z "s3_log_dir" ]; then
+if [ -z "$s3_log_dir" ]; then
   echo "Error: s3_log_dir unspecified."
   exit 10
 fi

--- a/scripts/SREP/mg-log-ls/script.sh
+++ b/scripts/SREP/mg-log-ls/script.sh
@@ -1,49 +1,49 @@
 #!/bin/bash
 
-# exit on error
+# Exit on error
 set -e
 
 export AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY
 
 hiveconfig=$(oc get hiveconfig hive -o json)
-if [ -z "$hiveconfig" ] ; then
+if [ -z "$hiveconfig" ]; then
   echo "Error: Unable to retrieve hiveconfig."
   exit 10
 fi
 
 bucket=$(echo "$hiveconfig" | jq -r '.spec.failedProvisionConfig.aws.bucket')
-if [ -z "$bucket" -o "$bucket" == "null" ] ; then
+if [ -z "$bucket" ] || [ "$bucket" == "null" ]; then
   echo "Error: Unable to determine S3 bucket from hiveconfig."
   exit 10
 fi
 
 region=$(echo "$hiveconfig" | jq -r '.spec.failedProvisionConfig.aws.region')
-if [ -z "$region" -o "$region" == "null" ] ; then
+if [ -z "$region" ] || [ "$region" == "null" ]; then
   echo "Error: Unable to determine AWS region from hiveconfig."
   exit 10
 fi
 
 secret_name=$(echo "$hiveconfig" | jq -r '.spec.failedProvisionConfig.aws.credentialsSecretRef.name')
-if [ -z "$secret_name" -o "$secret_name" == "null" ] ; then
+if [ -z "$secret_name" ] || [ "$secret_name" == "null" ]; then
   echo "Error: Unable to determine AWS credentials secret name from hiveconfig."
   exit 10
 fi
 
 credentials_secret=$(oc get secret -n hive -o json "$secret_name")
-if [ -z "$credentials_secret" -o "$credentials_secret" == "null" ] ; then
+if [ -z "$credentials_secret" ] || [ "$credentials_secret" == "null" ]; then
   echo "Error: Unable to retrieve credentials secret [$secret_name]."
   exit 10
 fi
 
 AWS_ACCESS_KEY_ID=$(echo "$credentials_secret" | jq -r '.data.aws_access_key_id' | base64 -d)
-if [ -z "$AWS_ACCESS_KEY_ID" -o "$AWS_ACCESS_KEY_ID" == "null" ] || [[ "$AWS_ACCESS_KEY_ID" != AKIA* ]] ; then
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ "$AWS_ACCESS_KEY_ID" == "null" ] || [[ "$AWS_ACCESS_KEY_ID" != AKIA* ]]; then
   echo "Error: Unable to retrieve aws_access_key_id from secret [$secret_name] in the hive namespace."
   exit 10
 fi
 
 AWS_SECRET_ACCESS_KEY=$(echo "$credentials_secret" | jq -r '.data.aws_secret_access_key' | base64 -d)
-if [ -z "$AWS_SECRET_ACCESS_KEY" -o "$AWS_SECRET_ACCESS_KEY" == "null" ]; then
+if [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ "$AWS_SECRET_ACCESS_KEY" == "null" ]; then
   echo "Error: Unable to retrieve aws_secret_access_key from secret [$secret_name] in the hive namespace."
   exit 10
 fi

--- a/scripts/SREP/retry-failed-pruning-cronjob/script.sh
+++ b/scripts/SREP/retry-failed-pruning-cronjob/script.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Delete and recreate jobs that fail in openshift-sre-pruning namespace and producing prunining cron job error.
+# Delete and recreate jobs that fail in openshift-sre-pruning namespace and produce pruning cron job errors.
 
 set -x
 set -e
@@ -14,45 +14,57 @@ FAILED_JOBS=()
 BUILDS_PRUNER_FAILED=()
 DEPLOYMENTS_PRUNER_FAILED=()
 
-BUILDS_PRUNER+=($(oc get jobs -n openshift-sre-pruning -o=jsonpath='{.items[?(@.metadata.ownerReferences[*].name=="builds-pruner")].metadata.name}'))
-DEPLOYMENTS_PRUNER+=($(oc get jobs -n openshift-sre-pruning -o=jsonpath='{.items[?(@.metadata.ownerReferences[*].name=="deployments-pruner")].metadata.name}'))
+mapfile -t BUILDS_PRUNER < <(oc get jobs -n "$PRUNING_NS" -o=jsonpath='{.items[?(@.metadata.ownerReferences[*].name=="builds-pruner")].metadata.name}')
+mapfile -t DEPLOYMENTS_PRUNER < <(oc get jobs -n "$PRUNING_NS" -o=jsonpath='{.items[?(@.metadata.ownerReferences[*].name=="deployments-pruner")].metadata.name}')
+
 detect_job() {
   echo "INFO: finding jobs producing error"
-  FAILED_JOBS+=($(oc get jobs -n "$PRUNING_NS" -o json | jq -r '.items[] | select(.status.succeeded != 1) | .metadata.name'))
+  mapfile -t FAILED_JOBS < <(oc get jobs -n "$PRUNING_NS" -o json | jq -r '.items[] | select(.status.succeeded != 1) | .metadata.name')
 }
 
 delete_job() {
-  if [[ ${#FAILED_JOBS[*]} == 0 ]]; then
-    echo "INFO: no failed jobs found exiting.."
+  if [[ ${#FAILED_JOBS[@]} -eq 0 ]]; then
+    echo "INFO: no failed jobs found, exiting.."
     exit 0
   else
     echo "INFO: deleting jobs producing error"
-    for jobs in "${FAILED_JOBS[@]}"; do
-      oc delete job "$jobs" -n "$PRUNING_NS"
+    for job in "${FAILED_JOBS[@]}"; do
+      oc delete job "$job" -n "$PRUNING_NS"
     done
   fi
 }
 
 rerun_job() {
-  for jobs in "${FAILED_JOBS[@]}"; do
-    if [[ ${BUILDS_PRUNER[@]} =~ ${jobs} ]]; then
-      BUILDS_PRUNER_FAILED+=("${jobs}")
-    elif [[ ${DEPLOYMENTS_PRUNER[@]} =~ ${jobs} ]]; then
-      DEPLOYMENTS_PRUNER_FAILED+=("${jobs}")
-    fi  
+  for job in "${FAILED_JOBS[@]}"; do
+    found=false
+    for pruner in "${BUILDS_PRUNER[@]}"; do
+      if [[ "$pruner" == "$job" ]]; then
+        BUILDS_PRUNER_FAILED+=("$job")
+        found=true
+        break
+      fi
+    done
+
+    if ! $found; then
+      for pruner in "${DEPLOYMENTS_PRUNER[@]}"; do
+        if [[ "$pruner" == "$job" ]]; then
+          DEPLOYMENTS_PRUNER_FAILED+=("$job")
+          break
+        fi
+      done
+    fi
   done
 
-  if [[ ${#BUILDS_PRUNER_FAILED[*]} != 0 ]]; then
-    echo "INFO: creating a builds puner job"
+  if [[ ${#BUILDS_PRUNER_FAILED[@]} -ne 0 ]]; then
+    echo "INFO: creating a builds pruner job"
     oc create job --from=cronjob/builds-pruner "${BUILDS_PRUNER_FAILED[0]}" -n "$PRUNING_NS"
   fi
 
-  if [[ ${#DEPLOYMENTS_PRUNER_FAILED[*]} != 0 ]]; then
-    echo "INFO: creating a deployments puner job"
+  if [[ ${#DEPLOYMENTS_PRUNER_FAILED[@]} -ne 0 ]]; then
+    echo "INFO: creating a deployments pruner job"
     oc create job --from=cronjob/deployments-pruner "${DEPLOYMENTS_PRUNER_FAILED[0]}" -n "$PRUNING_NS"
   fi
 }
-
 
 main() {
   detect_job

--- a/scripts/SREP/update-upgrade-policy-state/script.sh
+++ b/scripts/SREP/update-upgrade-policy-state/script.sh
@@ -74,7 +74,7 @@ CLUSTER_ID=$(get_cluster_id "${CLUSTER_UUID}")
 
 # 4. Get the policy UUID.
 POLICY_UUID=$(get_policy_uuid "${CLUSTER_ID}")
-if [[ $? -ne 0 ]]; then
+if [ -z "$POLICY_UUID" ]; then
     echo "Error fetching the policy UUID. Exiting."
     exit 1
 fi

--- a/scripts/examples/lib-sourcer/script.sh
+++ b/scripts/examples/lib-sourcer/script.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # i.e.
 # managed-scripts/scripts/examples/lib-sourcer/lib.sh
 # becomes
+# shellcheck source=/dev/null
 source /managed-scripts/lib/examples/lib.sh
 
 echo_import

--- a/scripts/lib/sftp_upload/lib.sh
+++ b/scripts/lib/sftp_upload/lib.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 # Constants
 readonly FTP_HOST="sftp.access.redhat.com"
-readonly SFTP_OPTIONS=(-o BatchMode=no -b)
+readonly SFTP_OPTIONS=("-o BatchMode=no" -b)
 readonly KNOWN_HOST='sftp.access.redhat.com,35.80.245.1 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCFQ3l2YVJ0r4MNzAZmTV2kg7rPi4WPeJNcNubvOVA4WwBV6cRsYFkIqtB1unBzTXoZHd7+adtZTgUrJ2BExImyLUQaLBu3KKo4CgGeiZMo8dfDvE2tIe/GwGtyho57TtwJVVUCljvFBvbz8+D6VunsQ6kNU53t8qCaBQNm61twTkdAHP9IESJbC7wWJqjmhmOMTav1OKQDtLEsSDc4I+s+h41LvUfw1lA7RSl9eR13TK9ySpN/uW5nBq7nUNWW5OBc3UbvpdQpDXvdUDbW0rQ2EEWvLkKubhk+RSeY/lH8peOeHYQ5ARPYfFDpo5KsKDDdKa9DfnK8N8APgtzM0r+l'
 
 ## Upload a file to sftp.access.redhat.com using the unauthenticated flow.
@@ -18,7 +18,7 @@ readonly KNOWN_HOST='sftp.access.redhat.com,35.80.245.1 ssh-rsa AAAAB3NzaC1yc2EA
 ## https://access.redhat.com/articles/5594481
 ##
 ## Usage: sftp_upload <source-filename> <destination-filename>
-## Exmaple: sftp_upload ${PWD}/must-gather.tar.gz must-gather.tar.gz
+## Example: sftp_upload ${PWD}/must-gather.tar.gz must-gather.tar.gz
 ## The <destination-filename> should be a filename not a path.
 function sftp_upload() {
     ## Set up known hosts file


### PR DESCRIPTION
### What type of PR is this?

_bug_

### What this PR does / Why we need it?
It will update the scripts as the shell check points out new errors. We've switched to EPEL8 as Centos7/RHEL7 reached EOL a month ago and they moved EPEL7 to archive [https://dl.fedoraproject.org/pub/epel/](https://dl.fedoraproject.org/pub/epel/) [https://dl.fedoraproject.org/pub/archive/epel/](https://dl.fedoraproject.org/pub/archive/epel/).

### Which Jira/Github issue(s) does this PR fix?

_Resolves_ #[OSD-24941](https://issues.redhat.com/browse/OSD-24941)

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR