### PR TITLE
Update script.sh for managedjob CEE/collect-verbose-ca-logs

### DIFF
--- a/scripts/CEE/collect-verbose-ca-logs/script.sh
+++ b/scripts/CEE/collect-verbose-ca-logs/script.sh
@@ -15,10 +15,10 @@ current_log_verbosity=$(oc get clusterautoscalers $CA_NAME -o jsonpath='{.spec.l
 
 # Check if current_log_verbosity is empty
 if [ -z "$current_log_verbosity" ]; then
-  echo "Failed to retrieve current logVerbosity value. \n\
-Kindly verify if the cluster autoscaling is enabled. To verify it, search the cluster on OCM (https://console.redhat.com/openshift/) and on the overview page, check if the cluster autoscaling section is \"Enabled\". If it is \"Disabled\", enable the cluster-autoscaling by following: \n\
-1. Search the cluster on OCM (https://console.redhat.com/openshift/) \n\
-2. Navigate to Machine Pools tab -> Click on \"Edit cluster autoscaling\" -> Save the desired settings."
+  printf "Failed to retrieve current logVerbosity value.\n\
+Kindly verify if the cluster autoscaling is enabled. To verify it, search the cluster on OCM (https://console.redhat.com/openshift/) and on the overview page, check if the cluster autoscaling section is \"Enabled\". If it is \"Disabled\", enable the cluster-autoscaling by following:\n\
+1. Search the cluster on OCM (https://console.redhat.com/openshift/)\n\
+2. Navigate to Machine Pools tab -> Click on \"Edit cluster autoscaling\" -> Save the desired settings.\n"
   exit 1
 fi
 

--- a/scripts/CEE/collect-verbose-ca-logs/script.sh
+++ b/scripts/CEE/collect-verbose-ca-logs/script.sh
@@ -15,7 +15,10 @@ current_log_verbosity=$(oc get clusterautoscalers $CA_NAME -o jsonpath='{.spec.l
 
 # Check if current_log_verbosity is empty
 if [ -z "$current_log_verbosity" ]; then
-  echo "Failed to retrieve current logVerbosity value."
+  echo "Failed to retrieve current logVerbosity value. \n\
+Kindly verify if the cluster autoscaling is enabled. To verify it, search the cluster on OCM (https://console.redhat.com/openshift/) and on the overview page, check if the cluster autoscaling section is \"Enabled\". If it is \"Disabled\", enable the cluster-autoscaling by following: \n\
+1. Search the cluster on OCM (https://console.redhat.com/openshift/) \n\
+2. Navigate to Machine Pools tab -> Click on \"Edit cluster autoscaling\" -> Save the desired settings."
   exit 1
 fi
 
@@ -34,8 +37,8 @@ echo
 # Wait for the update to take effect
 echo "Waiting for the log verbosity to update..."
 
-# Sleep for 5 seconds so that the new pod name gets reflected
-sleep 5
+# Sleep for 10 seconds so that the new pod name gets reflected
+sleep 10
 
 CA_POD=$(oc get pods -n openshift-machine-api | grep cluster-autoscaler-default | awk '{print $1}')
 echo "POD Name: $CA_POD"
@@ -95,8 +98,8 @@ echo
 echo "Waiting for the log verbosity to be reverted back..."
 echo
 
-# Sleep for 5 seconds so that the new pod name gets reflected
-sleep 5
+# Sleep for 10 seconds so that the new pod name gets reflected
+sleep 10
 
 CA_POD=$(oc get pods -n openshift-machine-api | grep cluster-autoscaler-default | awk '{print $1}')
 echo "POD Name: $CA_POD"


### PR DESCRIPTION
### Description
Modifying the message that gets displayed if the script is unable to retrieve logVebosity value. The descriptive message will help the user to verify if the autoscaling is properly enabled. Additionally, increasing the sleep time from 5 seconds to 10 seconds to address interim issues in pod name discrepancy.

### What type of PR is this?
Script improvement

### What this PR does / Why we need it?
The PR has following changes:
- Modifying the message that gets displayed if the script is unable to retrieve logVebosity value.
- Increasing the sleep time from 5 seconds to 10 seconds to address interim issues in pod name discrepancy.
