### PR TITLE
OSD-25772 fix permission issue and add note for debug handler

### DIFF
--- a/scripts/CEE/hs-must-gather/README.md
+++ b/scripts/CEE/hs-must-gather/README.md
@@ -11,8 +11,12 @@ The script will upload the compressed dump to the [SFTP](https://access.redhat.c
 
 Parameters:
 - CLUSTER_ID: hosted cluster id.
+- DUMP_GUEST_CLUSTER(true|false): also dump the must gather in the guest cluster.
 
 In the management cluster:
 ```bash
-ocm backplane managedjob create CEE/hs-must-gather -p CLUSTER_ID=my-hs-cluster-id
+ocm backplane managedjob create CEE/hs-must-gather -p CLUSTER_ID=my-hs-cluster-id -p DUMP_GUEST_CLUSTER=false
 ```
+
+Note:
+The debug handler is disabled in the production environment. Logs can not be collected by hypershift dump, and DUMP_GUEST_CLUSTER won't work in the production environment. Please use `osdctl cluster dt gather-logs` to collect logs in the production environment.

--- a/scripts/CEE/hs-must-gather/script.sh
+++ b/scripts/CEE/hs-must-gather/script.sh
@@ -9,7 +9,7 @@ source /managed-scripts/lib/sftp_upload/lib.sh
 
 # Define expected values
 HS_BINARY_PATH="/usr/local/bin/hypershift"
-DUMP_DIR="${PWD}/${CLUSTER_ID}"
+DUMP_DIR="/tmp/${CLUSTER_ID}"
 TODAY=$(date -u +%Y%m%d)
 TARBALL_NAME="${TODAY}_${CLUSTER_ID}_dump.tar.gz"
 TARBALL_PATH="${DUMP_DIR}/${TARBALL_NAME}"


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

The latest MG container has permission issue with PWD=root.
```
ERROR	Cannot create directory	{"directory": "/root/xxxxxxx/network_logs", "error": "mkdir /root/xxxxxxx: permission denied"}
```
This PR changes to use `/tmp/` to store the dump data.

Also, as debug handler is disabled in the production environment, it couldn't dump guest cluster logs.
```
ERROR	Failed to dump guest cluster	{"error": "cannot forward kube apiserver port: error upgrading connection: unable to upgrade connection: Debug endpoints are disabled., output: "}
```
This PR adds a note in the README to suggest to use `osdctl` instead.

### Which Jira/Github issue(s) does this PR fix?

https://issues.redhat.com/browse/OSD-25772

### Special notes for your reviewer

Validated in a staging cluster by `ocm backplane testjob` and the /tmp/ directory works for staging.

### Pre-checks (if applicable)

- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR