### PR TITLE
adds mcs tier two role to BPMS

### DIFF
--- a/scripts/CEE/check-tech-preview-features/metadata.yaml
+++ b/scripts/CEE/check-tech-preview-features/metadata.yaml
@@ -6,23 +6,23 @@ author: supreeth7
 allowedGroups:
   - CEE
   - SREP
-  - LPSRE                      
+  - LPSRE
+  - TierTwoSupport
 rbac:
-    clusterRoleRules:
-      - apiGroups:
+  clusterRoleRules:
+    - apiGroups:
         - "config.openshift.io"
-        resources:
+      resources:
         - featuregates
-        verbs:
+      verbs:
         - "get"
         - "list"
-      - apiGroups:
+    - apiGroups:
         - "operator.openshift.io"
-        resources:
+      resources:
         - "kubeapiservers"
-        verbs:
+      verbs:
         - "get"
         - "list"
-
 language: bash
 customerDataAccess: false

--- a/scripts/CEE/cluster-health-check/metadata.yaml
+++ b/scripts/CEE/cluster-health-check/metadata.yaml
@@ -6,6 +6,7 @@ allowedGroups:
   - CEE
   - SREP
   - LPSRE
+  - TierTwoSupport
 rbac:
   clusterRoleRules:
     - verbs:

--- a/scripts/CEE/collect-verbose-ca-logs/metadata.yaml
+++ b/scripts/CEE/collect-verbose-ca-logs/metadata.yaml
@@ -5,32 +5,33 @@ author: Kushagra Kulshreshtha
 allowedGroups:
   - CEE
   - SREP
+  - TierTwoSupport
 rbac:
   roles:
     - namespace: "openshift-machine-api"
       rules:
         - verbs:
-          - "get"
-          - "logs"
+            - "get"
+            - "logs"
           apiGroups:
-          - "clusterautoscaler.autoscaling.openshift.io"
+            - "clusterautoscaler.autoscaling.openshift.io"
           resources:
-          - "pods"
-          - "pods/attach"
+            - "pods"
+            - "pods/attach"
   clusterRoleRules:
-      - verbs:
+    - verbs:
         - "get"
         - "patch"
-        apiGroups:
+      apiGroups:
         - "autoscaling.openshift.io"
-        resources:
+      resources:
         - "clusterautoscalers"
-      - verbs:
+    - verbs:
         - "get"
         - "list"
-        apiGroups:
+      apiGroups:
         - ""
-        resources:
+      resources:
         - "nodes"
 language: bash
 customerDataAccess: false

--- a/scripts/CEE/delete-worker-node/metadata.yaml
+++ b/scripts/CEE/delete-worker-node/metadata.yaml
@@ -5,6 +5,7 @@ author: Nelson Paez
 allowedGroups:
   - CEE
   - SREP
+  - TierTwoSupport
 rbac:
   clusterRoleRules:
     - verbs:
@@ -29,10 +30,8 @@ envs:
   - key: NODE
     description: The node name
     optional: false
-
   - key: MACHINE
     description: The machine name associated with the node
     optional: false
-
 language: bash
 customerDataAccess: false

--- a/scripts/CEE/describe-kafka-transaction/metadata.yaml
+++ b/scripts/CEE/describe-kafka-transaction/metadata.yaml
@@ -7,6 +7,7 @@ allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 rbac:
   clusterRoleRules:
     - verbs:

--- a/scripts/CEE/etcd-health-check/metadata.yaml
+++ b/scripts/CEE/etcd-health-check/metadata.yaml
@@ -2,26 +2,27 @@ file: script.sh
 name: etcd-health-check
 description: Prints out the etcd health info.
 author: feichashao
-allowedGroups: 
+allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 rbac:
-    roles:
-      - namespace: "openshift-etcd"
-        rules:
-          - verbs:
+  roles:
+    - namespace: "openshift-etcd"
+      rules:
+        - verbs:
             - "get"
             - "list"
-            apiGroups:
+          apiGroups:
             - ""
-            resources:
+          resources:
             - "pods"
-          - verbs:
+        - verbs:
             - "create"
-            apiGroups:
+          apiGroups:
             - ""
-            resources:
+          resources:
             - "pods/exec"
 language: bash
 customerDataAccess: true

--- a/scripts/CEE/get-events/metadata.yaml
+++ b/scripts/CEE/get-events/metadata.yaml
@@ -5,6 +5,7 @@ author: Daniel Fernandez
 allowedGroups:
   - CEE
   - SREP
+  - TierTwoSupport
 rbac:
   clusterRoleRules:
     - verbs:
@@ -15,11 +16,9 @@ rbac:
       resources:
         - namespaces
         - events
-
 envs:
   - key: namespace
     description: Namespace(s) from which to retrieve and display the PDBs.
     optional: true
-
 language: bash
 customerDataAccess: true

--- a/scripts/CEE/get-kafka-instance-state/metadata.yaml
+++ b/scripts/CEE/get-kafka-instance-state/metadata.yaml
@@ -12,6 +12,7 @@ allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 rbac:
   clusterRoleRules:
     - verbs:

--- a/scripts/CEE/get-rhoc-connector-info/metadata.yaml
+++ b/scripts/CEE/get-rhoc-connector-info/metadata.yaml
@@ -9,6 +9,7 @@ allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 rbac:
   clusterRoleRules:
     # connectors   

--- a/scripts/CEE/get-rhosak-operators/metadata.yaml
+++ b/scripts/CEE/get-rhosak-operators/metadata.yaml
@@ -6,12 +6,12 @@ description: |
     * managed-application-services-observability
     * redhat-kas-fleetshard-operator
     * redhat-managed-kafka-operator
-
 author: Rachel Lawton
 allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 envs:
   - key: 'since'
     description: "The --since flag is used by the oc adm inspect command. Only return logs newer than a relative duration. Either since can be added or since_time can be added but not both."

--- a/scripts/CEE/hs-must-gather/metadata.yaml
+++ b/scripts/CEE/hs-must-gather/metadata.yaml
@@ -1,11 +1,12 @@
 file: script.sh
-name: hs-must-gather 
+name: hs-must-gather
 description: Hypershift must gather script
 author: sjayasin
-allowedGroups: 
+allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 labels:
   - key: OSD_TYPES
     description: Compatible cluster types for this script
@@ -101,6 +102,6 @@ envs:
     optional: false
   - key: "DUMP_GUEST_CLUSTER"
     description: "Include the guest cluster the must gather"
-    optional: false 
+    optional: false
 language: bash
 customerDataAccess: true

--- a/scripts/CEE/kubelet-restart/metadata.yaml
+++ b/scripts/CEE/kubelet-restart/metadata.yaml
@@ -6,33 +6,34 @@ allowedGroups:
   - SREP
   - LPSRE
   - CEE
+  - TierTwoSupport
 rbac:
   roles:
     - namespace: "default"
       rules:
         - verbs:
-          - "get"
-          - "patch"
-          - "list"
-          - "watch"
-          - "create"
-          - "delete"
+            - "get"
+            - "patch"
+            - "list"
+            - "watch"
+            - "create"
+            - "delete"
           apiGroups:
-          - ""
+            - ""
           resources:
-          - "pods"
-          - "pods/attach"
+            - "pods"
+            - "pods/attach"
   clusterRoleRules:
-      - verbs:
+    - verbs:
         - "get"
         - "patch"
         - "list"
         - "watch"
-        apiGroups:
+      apiGroups:
         - ""
-        resources:
+      resources:
         - "nodes"
-envs:          
+envs:
   - key: NODE
     description: The node name
     optional: false

--- a/scripts/CEE/list-alerts/metadata.yaml
+++ b/scripts/CEE/list-alerts/metadata.yaml
@@ -1,30 +1,31 @@
 file: script.sh
 name: list-alerts
-description: Lists the active/pending alerts in alertmanager. It also provide an option to list active silences. 
+description: Lists the active/pending alerts in alertmanager. It also provide an option to list active silences.
 author: bdematte
-allowedGroups: 
+allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 rbac:
-    roles:
-      - namespace: "openshift-monitoring"
-        rules:
-          - verbs:
+  roles:
+    - namespace: "openshift-monitoring"
+      rules:
+        - verbs:
             - "get"
             - "list"
-            apiGroups:
+          apiGroups:
             - ""
-            resources:
+          resources:
             - "secrets"
             - "serviceaccounts"
             - "namespaces"
-          - verbs:
+        - verbs:
             - "get"
             - "list"
-            apiGroups:
+          apiGroups:
             - "route.openshift.io"
-            resources:
+          resources:
             - "routes"
 envs:
   - key: "SCRIPT_PARAMETERS"

--- a/scripts/CEE/pcap-collector/metadata.yaml
+++ b/scripts/CEE/pcap-collector/metadata.yaml
@@ -3,7 +3,7 @@ name: pcap-collector
 shortDescription: Captures traffic on nodes and produce gzipped pcap file.
 description: |
   Capture network traffic with tcpdump on a node and then send the capture to the case SFTP server and ticket.
-  
+
   This script will only work if a secret exists in the managed scripts namespace that contains a valid single-use
   SFTP token.
 
@@ -19,13 +19,13 @@ description: |
     5. If the job completes, a gzipped pcap file should be available at your case URL.
 
     See https://source.redhat.com/groups/public/openshiftplatformsre/wiki/how_to_use_the_must_gather_operator for inspiration and reference.
-
 author: John Roche, Hector Kemp
 allowedGroups:
   - SREP
   - CEE
+  - TierTwoSupport
 rbac:
-    clusterRoleRules:
+  clusterRoleRules:
     - verbs:
         - "get"
         - "create"

--- a/scripts/CEE/registry-s3-bucket-size/metadata.yaml
+++ b/scripts/CEE/registry-s3-bucket-size/metadata.yaml
@@ -6,24 +6,25 @@ author: karthikperu7
 allowedGroups:
   - CEE
   - SREP
+  - TierTwoSupport
 rbac:
-    roles:
-      - namespace: "openshift-image-registry"
-        rules:
-          - verbs:
+  roles:
+    - namespace: "openshift-image-registry"
+      rules:
+        - verbs:
             - "get"
             - "list"
-            apiGroups:
+          apiGroups:
             - ""
-            resources:
+          resources:
             - "secrets"
-    clusterRoleRules:
-      - verbs:
+  clusterRoleRules:
+    - verbs:
         - "get"
         - "list"
-        apiGroups:
+      apiGroups:
         - "imageregistry.operator.openshift.io"
-        resources:
+      resources:
         - configs
 language: bash
 customerDataAccess: false

--- a/scripts/CEE/restart-dns-default/metadata.yaml
+++ b/scripts/CEE/restart-dns-default/metadata.yaml
@@ -6,19 +6,20 @@ allowedGroups:
   - SREP
   - LPSRE
   - CEE
+  - TierTwoSupport
 rbac:
- roles:
-   - namespace: "openshift-dns"
-     rules:
-       - verbs:
-         - "get"
-         - "patch"
-         - "list"
-         - "watch"
-         apiGroups:
-         - "apps"
-         resources:
-         - "daemonsets"
-         - "pods"
+  roles:
+    - namespace: "openshift-dns"
+      rules:
+        - verbs:
+            - "get"
+            - "patch"
+            - "list"
+            - "watch"
+          apiGroups:
+            - "apps"
+          resources:
+            - "daemonsets"
+            - "pods"
 language: bash
 customerDataAccess: false

--- a/scripts/CEE/worker-node-operations/metadata.yaml
+++ b/scripts/CEE/worker-node-operations/metadata.yaml
@@ -5,42 +5,43 @@ author: Fabio Aldana
 allowedGroups:
   - CEE
   - SREP
+  - TierTwoSupport
 rbac:
   roles:
     - namespace: "default"
       rules:
         - verbs:
-          - "get"
-          - "patch"
-          - "list"
-          - "watch"
-          - "create"
-          - "delete"
+            - "get"
+            - "patch"
+            - "list"
+            - "watch"
+            - "create"
+            - "delete"
           apiGroups:
-          - ""
+            - ""
           resources:
-          - "pods"
-          - "pods/attach"
+            - "pods"
+            - "pods/attach"
   clusterRoleRules:
-      - verbs:
+    - verbs:
         - "get"
         - "patch"
         - "list"
         - "watch"
-        apiGroups:
+      apiGroups:
         - ""
-        resources:
+      resources:
         - "nodes"
         - "nodes/proxy"
-      - verbs:
+    - verbs:
         - "get"
         - "list"
         - "watch"
         - "delete"
         - "create"
-        apiGroups:
+      apiGroups:
         - ""
-        resources:
+      resources:
         - "pods"
         - "pods/eviction"
 envs:

--- a/scripts/SREP/cluster-operator-status/metadata.yaml
+++ b/scripts/SREP/cluster-operator-status/metadata.yaml
@@ -2,34 +2,35 @@ file: script.sh
 name: cluster-operator-status # name should be the same as the subdir, eg: SRE/example in this case
 description: Retrieves status of the cluster's Cluster Operators
 author: mbargenq
-allowedGroups: 
+allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 rbac:
-    roles: []
-    clusterRoleRules:
+  roles: []
+  clusterRoleRules:
     - verbs:
-      - "get"
-      - "list"
+        - "get"
+        - "list"
       apiGroups:
-      - "config.openshift.io"
+        - "config.openshift.io"
       resources:
-      - clusteroperators
+        - clusteroperators
     - verbs:
-      - "get"
-      - "list"
+        - "get"
+        - "list"
       apiGroups:
-      - "apps"
+        - "apps"
       resources:
-      - deployments
+        - deployments
     - verbs:
-      - "get"
-      - "list"
+        - "get"
+        - "list"
       apiGroups:
-      - ""
+        - ""
       resources:
-      - pods
+        - pods
 envs:
   - key: "CLUSTER_OPERATOR"
     description: "Cluster Operator to specifically target."

--- a/scripts/SREP/describe-nodes/metadata.yaml
+++ b/scripts/SREP/describe-nodes/metadata.yaml
@@ -2,24 +2,25 @@ file: script.sh
 name: describe-nodes
 description: Provide the full functionality of `oc describe nodes`, as the standard `oc describe nodes` in backplane restricts access to customer workload information.
 author: dsquirre
-allowedGroups: 
+allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 rbac:
-    roles:
-      - namespace: "kube-node-lease"
-        rules:
-          - apiGroups: ['coordination.k8s.io']
-            resources: ['leases']
-            verbs:     ['get', 'list']
-    clusterRoleRules:
-        - apiGroups: ['']
-          resources: ['nodes']
-          verbs:     ['get', 'list']
-        - apiGroups: ['']
-          resources: ['pods']
-          verbs:     ['get', 'list']
+  roles:
+    - namespace: "kube-node-lease"
+      rules:
+        - apiGroups: ['coordination.k8s.io']
+          resources: ['leases']
+          verbs: ['get', 'list']
+  clusterRoleRules:
+    - apiGroups: ['']
+      resources: ['nodes']
+      verbs: ['get', 'list']
+    - apiGroups: ['']
+      resources: ['pods']
+      verbs: ['get', 'list']
 envs:
   - key: "SCRIPT_PARAMETERS"
     description: "Parameters to be passed to the script. You can set the variable to '--help' to get list of supported parameters"
@@ -32,4 +33,3 @@ labels:
       - HyperShift
     optional: true
 customerDataAccess: true
-      

--- a/scripts/SREP/elasticsearch-status/metadata.yaml
+++ b/scripts/SREP/elasticsearch-status/metadata.yaml
@@ -2,20 +2,21 @@ file: script.sh
 name: elasticsearch-status # name should be the same as the subdir, eg: SRE/example in this case
 description: Check status of elastic search on clusters
 author: lfalconm
-allowedGroups: 
+allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 rbac:
-    roles:
-      - namespace: "openshift-monitoring"
-        rules:
-          - verbs:
+  roles:
+    - namespace: "openshift-monitoring"
+      rules:
+        - verbs:
             - "get"
             - "list"
-            apiGroups:
+          apiGroups:
             - ""
-            resources:
+          resources:
             - "pods"
             - "clusterlogging"
             - "elasticsearch"
@@ -23,18 +24,18 @@ rbac:
             - "deployment"
             - "resourcequota"
             - "persistentvolumeclaim"
-          - verbs:
+        - verbs:
             - "create"
-            apiGroups:
+          apiGroups:
             - ""
-            resources:
+          resources:
             - "pods/exec"
-          - verbs:
+        - verbs:
             - "get"
             - "list"
-            apiGroups:
+          apiGroups:
             - "operators.coreos.com"
-            resources:
+          resources:
             - "subscriptions"
 language: bash
 customerDataAccess: false

--- a/scripts/SREP/etcd-complete-health-check/metadata.yaml
+++ b/scripts/SREP/etcd-complete-health-check/metadata.yaml
@@ -1,56 +1,57 @@
 file: script.sh
 name: etcd-complete-health-check
 description: Prints out the complete health check for etcd with recent logs incase of unhealthy clusters
-author: devppratik 
+author: devppratik
 allowedGroups:
   - SREP
   - LPSRE
   - CEE
+  - TierTwoSupport
 labels:
   - key: OSD_TYPES
     description: Compatible cluster types for this script
     values:
       - OSD
 rbac:
-    roles:
-      - namespace: "openshift-etcd"
-        rules:
-          - verbs:
+  roles:
+    - namespace: "openshift-etcd"
+      rules:
+        - verbs:
             - "get"
             - "list"
-            apiGroups:
+          apiGroups:
             - ""
-            resources:
+          resources:
             - "pods"
-          - verbs:
+        - verbs:
             - "create"
-            apiGroups:
+          apiGroups:
             - ""
-            resources:
+          resources:
             - "pods/exec"
-      - namespace: "default"
-        rules:
-          - verbs:
+    - namespace: "default"
+      rules:
+        - verbs:
             - "create"
             - "delete"
-            apiGroups:
+          apiGroups:
             - ""
-            resources:
+          resources:
             - "pods"
-    clusterRoleRules:
-        - verbs:
-            - "get"
-            - "list"
-          apiGroups:
-            - ""
-          resources:
-            - "nodes"
-        - verbs:
-            - "get"
-            - "list"
-          apiGroups:
-            - "operator.openshift.io"
-          resources:
-            - "etcds"
+  clusterRoleRules:
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - ""
+      resources:
+        - "nodes"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "operator.openshift.io"
+      resources:
+        - "etcds"
 language: bash
 customerDataAccess: true

--- a/scripts/SREP/example/metadata.yaml
+++ b/scripts/SREP/example/metadata.yaml
@@ -2,10 +2,11 @@ file: script.sh
 name: example # name should be the same as the subdir, eg: SRE/example in this case
 description: Example script
 author: qhua948
-allowedGroups: 
+allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 labels:
   - key: OSD_TYPES
     description: Compatible cluster types for this script
@@ -13,25 +14,25 @@ labels:
       - OSD
       - HyperShift
 rbac:
-    roles:
-      - namespace: "openshift-monitoring"
-        rules:
-          - verbs:
-            - "get"
-            - "list"
-            apiGroups:
-            - ""
-            resources:
-            - "pods"
-    clusterRoleRules:
+  roles:
+    - namespace: "openshift-monitoring"
+      rules:
         - verbs:
             - "get"
             - "list"
-            - "watch"
           apiGroups:
             - ""
           resources:
-            - "jobs"
+            - "pods"
+  clusterRoleRules:
+    - verbs:
+        - "get"
+        - "list"
+        - "watch"
+      apiGroups:
+        - ""
+      resources:
+        - "jobs"
 envs:
   - key: "var1"
     description: "variable 1"

--- a/scripts/SREP/get-pull-secret-email/metadata.yaml
+++ b/scripts/SREP/get-pull-secret-email/metadata.yaml
@@ -6,6 +6,7 @@ allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 labels:
   - key: OSD_TYPES
     description: Compatible cluster types for this script
@@ -13,14 +14,14 @@ labels:
       - OSD
       - HyperShift
 rbac:
-    roles:
-      - namespace: "openshift-config"
-        rules:
-          - verbs:
+  roles:
+    - namespace: "openshift-config"
+      rules:
+        - verbs:
             - "get"
-            apiGroups:
+          apiGroups:
             - ""
-            resources:
+          resources:
             - "secrets"
 language: bash
 customerDataAccess: false

--- a/scripts/SREP/get-targets-down/metadata.yaml
+++ b/scripts/SREP/get-targets-down/metadata.yaml
@@ -2,33 +2,34 @@ file: script.sh
 name: get-targets-down # name should be the same as the subdir, eg: SRE/example in this case
 description: Lists pods marked as down by cluster Prometheus
 author: mdewald
-allowedGroups: 
+allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 rbac:
-    roles:
-      - namespace: "openshift-monitoring"
-        rules:
-          - verbs:
+  roles:
+    - namespace: "openshift-monitoring"
+      rules:
+        - verbs:
             - "get"
-            apiGroups:
+          apiGroups:
             - ""
-            resources:
+          resources:
             - "serviceaccounts"
-          - verbs:
+        - verbs:
             - "create"
-            apiGroups:
+          apiGroups:
             - ""
-            resources:
+          resources:
             - "serviceaccounts/token"
-    clusterRoleRules:
+  clusterRoleRules:
     - verbs:
-      - "get"
-      - "list"
+        - "get"
+        - "list"
       apiGroups:
-      - ""
+        - ""
       resources:
-      - "pods"
+        - "pods"
 language: bash
 customerDataAccess: true

--- a/scripts/SREP/node-logs/metadata.yaml
+++ b/scripts/SREP/node-logs/metadata.yaml
@@ -6,15 +6,16 @@ allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 rbac:
-    clusterRoleRules:
-        - verbs:
-            - "get"
-          apiGroups:
-            - ""
-          resources:
-            - "nodes"
-            - "nodes/proxy"
+  clusterRoleRules:
+    - verbs:
+        - "get"
+      apiGroups:
+        - ""
+      resources:
+        - "nodes"
+        - "nodes/proxy"
 envs:
   - key: "node"
     description: "node name"

--- a/scripts/SREP/tsdb-status/metadata.yaml
+++ b/scripts/SREP/tsdb-status/metadata.yaml
@@ -7,18 +7,18 @@ allowedGroups:
   - SREP
   - CEE
   - LPSRE
+  - TierTwoSupport
 rbac:
-    roles:
-      - namespace: "openshift-monitoring"
-        rules:
-          - apiGroups: [""]
-            verbs: ["get"]
-            resources: 
+  roles:
+    - namespace: "openshift-monitoring"
+      rules:
+        - apiGroups: [""]
+          verbs: ["get"]
+          resources:
             - "secrets"
             - "serviceaccounts"
-          - apiGroups: ["route.openshift.io"]
-            verbs: ["get"]
-            resources: 
+        - apiGroups: ["route.openshift.io"]
+          verbs: ["get"]
+          resources:
             - "routes"
 customerDataAccess: false
-


### PR DESCRIPTION
### What type of PR is this?

Feature/Cleanup

### What this PR does / Why we need it?

Adds the TierTwoSupport user role to the Backplane Managed Scripts

Also seems to be lots of `yq` formatting since I piped this all through `yq` using:

```
for folder in `find scripts -type d`; do echo "Dir: $folder"; if stat "$folder/metadata.yaml" >&/dev/null; then; if yq '.allowedGroups' "$folder/metadata.yaml" | grep CEE; then yq e -i '.allowedGroups += [ "TierTwoSupport" ]' "$folder/metadata.yaml" >&/dev/null; echo "  Updated"; fi; else; echo "  No CEE access"; fi; done
```

### Which Jira/Github issue(s) does this PR fix?

_Resolves [OSD-26528](https://issues.redhat.com/browse/OSD-26528)_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR