### PR TITLE
WIP: [MTSRE-2013] Add extend-acs-tenant-expiration script to extend acs tenant expiration

### DIFF
--- a/scripts/LPSRE/extend-acs-tenant-expiration/metadata.yaml
+++ b/scripts/LPSRE/extend-acs-tenant-expiration/metadata.yaml
@@ -1,0 +1,23 @@
+file: script.sh
+name: extend-acs-tenant-expiration # name should be the same as the subdir, eg: SRE/example in this case
+description: Extend ACS tenant expiration time, defaults to 6 months, requires RHOAS_TOKEN, TENANT_ID and REASON.
+author: todabasi
+allowedGroups:
+  - LPSRE
+rbac:
+    roles: #TODO
+envs:
+  - key: "RHOAS_TOKEN"
+    description: "RHOAS token obtained using 'rhoas login --auth-url=https://auth.redhat.com/auth/realms/EmployeeIDP' and supplied using '-p RHOAS_TOKEN=$(rhoas authtoken)'"
+    optional: false
+  - key: "TENANT_ID"
+    description: "Tennant ID of a secured cluster that requires extention"
+    optional: false
+  - key: "REASON"
+    description: "Reason for extending a tennant including jira card"
+    optional: false
+  - key: "MONTHS"
+    description: "Period for extending a tennat, defaults to 6 months"
+    optional: true
+language: bash
+customerDataAccess: false

--- a/scripts/LPSRE/extend-acs-tenant-expiration/script.sh
+++ b/scripts/LPSRE/extend-acs-tenant-expiration/script.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+set -o pipefail
+
+MISSING_ARG_ERR_CODE=2
+
+usage() {
+    cat <<EOF >&2
+Usage: ocm backplane managedjob create LPSRE/increase-acs-tenant-expiration -p RHOAS_TOKEN=<RHOAS_TOKEN> -p TENANT_ID=<TENANT_ID> -p MONTHS=<MONTHS> -p REASON=<REASON>
+EOF
+}
+
+if [[ -z "${RHOAS_TOKEN}" ]]; then
+    echo "RHOAS token is not set, get token using 'rhoas authtoken' command and pass using -p RHOAS_TOKEN=<RHOAS_TOKEN>"
+    usage
+    exit "${MISSING_ARG_ERR_CODE}"
+fi
+
+if [[ -z "${TENANT_ID}" ]]; then
+    echo "Tenant id is not set, pass using -p TENANT_ID=<TENANT_ID>"
+    usage
+    exit "${MISSING_ARG_ERR_CODE}"
+fi
+
+if [[ -z "${REASON}" ]]; then
+    echo "Reason is not set, pass using -p REASON=<REASON>"
+    usage
+    exit "${MISSING_ARG_ERR_CODE}"
+fi
+
+if [[ -z "${MONTHS}" ]]; then
+    echo "Defaulting timestamp to 6 months"
+    TIMESTAMP=$(date --iso-8601=seconds --utc -d "+6 months")
+elif
+    TIMESTAMP=$(date --iso-8601=seconds --utc -d "+${MONTHS} months")
+fi
+
+update_tenant() {
+    curl -H "Authorization: Bearer ${RHOAS_TOKEN}" \
+        "https://api.openshift.com/api/rhacs/v1/admin/centrals/${TENANT_ID}/expired-at" \
+        -X PATCH \
+        --data-urlencode "timestamp=${TIMESTAMP}" --data-urlencode "reason=${REASON}"
+}
+
+
+main(){
+    update_tenant
+    exit 0
+}
+
+main "$@"


### PR DESCRIPTION
Adds extend-acs-tenant-expiration script to extend acs tenant expiration

### What type of PR is this?

_feature_

### What this PR does / Why we need it?

create a managed-script to extend the ACS tenant from expiring.

Acceptance Criteria
automate this SOP [here](https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/cp-002-change-tenant-expiration-date.md?ref_type=heads)

### Which Jira/Github issue(s) does this PR fix?

_Resolves [MTSRE-2013](https://issues.redhat.com//browse/MTSRE-2013)_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR