### PR TITLE
Get haproxy config

### DIFF
--- a/scripts/CEE/get-haproxy-config/README.md
+++ b/scripts/CEE/get-haproxy-config/README.md
@@ -1,0 +1,29 @@
+# get-haproxy-config
+
+This script prints the HAProxy configuration from one of the router pods in an
+OpenShift cluster.
+
+
+### Usage
+
+The script optionally accepts the name of a pod in the openshift-ingress
+namespace as an argument; when run with no arguments, the first router pod
+from the default ingress controller will be used.
+
+**Get the contents of haproxy.config from the first router pod**
+
+```bash
+ocm backplane managedjob create CEE/get-haproxy-config
+```
+
+**Get the contents of haproxy.config from a specific pod**:
+
+```bash
+ocm backplane managedjob create CEE/get-haproxy-config -p ROUTER=<pod_name>
+```
+
+
+### Important Notes
+
+- The script utilizes the `oc` command-line tool, and the user running the script should have the necessary permissions to access the cluster.
+- This script is read-only and does not modify any resources in the cluster.

--- a/scripts/CEE/get-haproxy-config/metadata.yaml
+++ b/scripts/CEE/get-haproxy-config/metadata.yaml
@@ -1,0 +1,25 @@
+---
+file: script.sh
+name: get-haproxy-config
+shortDescription: prints the contents of router pod's haproxy.config
+description: Prints the content of haproxy.config from a router pod to standard output.
+author: gvnnn
+language: bash
+allowedGroups:
+  - CEE
+  - SREP
+customerDataAccess: false
+rbac:
+  clusterRoleRules:
+    - apiGroups: ['']
+      resources: ['pods']
+      verbs:
+        - get
+        - list
+    - apiGroups: ['']
+      resources: ['pods/exec']
+      verbs: ['create']
+envs:
+  - key: ROUTER
+    description: The pod name you wish to print the configuration from
+    optional: true

--- a/scripts/CEE/get-haproxy-config/script.sh
+++ b/scripts/CEE/get-haproxy-config/script.sh
@@ -5,6 +5,10 @@
 # file is printed; if no router pod is passed, the first default router in
 # openshift-ingress is used.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 INGRESS_NS="openshift-ingress"
 OC_PARAMS="--namespace=${INGRESS_NS} \
 	   --output=custom-columns=:.metadata.name\
@@ -13,12 +17,12 @@ OC_CMD="oc get pods ${OC_PARAMS}"
 SELECTOR="ingresscontroller.operator.openshift.io/deployment-ingresscontroller"
 CFG_PATH="/var/lib/haproxy/conf/haproxy.config"
 
-if [ -n "${ROUTER}" ]; then
+if [ -n "${ROUTER:-}" ]; then
 	POD="$(${OC_CMD} "${ROUTER}")" || exit
 else
 	POD="$(${OC_CMD} \
 		--selector=${SELECTOR}=default \
-		--field-selector=status.phase==Running | \
+		--field-selector=status.phase==Running |
 		head --lines=1)"
 fi
 

--- a/scripts/CEE/get-haproxy-config/script.sh
+++ b/scripts/CEE/get-haproxy-config/script.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Prints the content of haproxy.config from a router to standard output.
+# If a pod name is passed as argument, the contents of that pod's configuration
+# file is printed; if no router pod is passed, the first default router in
+# openshift-ingress is used.
+
+INGRESS_NS="openshift-ingress"
+OC_PARAMS="--namespace=${INGRESS_NS} \
+	   --output=custom-columns=:.metadata.name\
+	   --no-headers"
+OC_CMD="oc get pods ${OC_PARAMS}"
+SELECTOR="ingresscontroller.operator.openshift.io/deployment-ingresscontroller"
+CFG_PATH="/var/lib/haproxy/conf/haproxy.config"
+
+if [ -n "${ROUTER}" ]; then
+	POD="$(${OC_CMD} "${ROUTER}")" || exit
+else
+	POD="$(${OC_CMD} \
+		--selector=${SELECTOR}=default \
+		--field-selector=status.phase==Running | \
+		head --lines=1)"
+fi
+
+if [ -z "${POD}" ]; then
+	echo "No running router found. Exiting."
+	exit 1
+fi
+
+echo -e "haproxy.config from ${POD}:\n\n"
+
+oc -n "${INGRESS_NS}" exec "${POD}" -- cat "${CFG_PATH}"


### PR DESCRIPTION
### What type of PR is this?

This adds a new managed script to print the contents of the `/var/lib/haproxy/conf/haproxy.config` file from one of the default router pods.

### What this PR does / Why we need it?

This helps troubleshooting Ingress connection issues such as misconfigured routes or mismatched routes/endpoints.

### Which Jira/Github issue(s) does this PR fix?

[OSD-26547](https://issues.redhat.com/browse/OSD-26547)

### Pre-checks

I have tested this in a staging cluster.