### PR TITLE
fix(Dockerfile): use 'rm -f' to avoid errors when cleanup files are missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,5 +144,5 @@ RUN oc completion bash > /etc/bash_completion.d/oc
 RUN aws --version
 
 # Cleanup Home Dir
-RUN rm /root/anaconda* /root/original-ks.cfg
+RUN rm -f /root/anaconda* /root/original-ks.cfg
 WORKDIR /root


### PR DESCRIPTION

### What type of PR is this?

_(bug/feature/cleanup/documentation)_
bug

### What this PR does / Why we need it?

This PR updates the Dockerfile to use `rm -f `when removing cleanup files `(/root/anaconda*, /root/original-ks.cfg)`. This prevents build failures when the files are not present in the image.

### Pre-checks (if applicable)

- [X] Validated the changes by building image locally
