### PR TITLE
Fixing start_job and finish_job functions

### DIFF
--- a/scripts/CEE/worker-node-operations/script.sh
+++ b/scripts/CEE/worker-node-operations/script.sh
@@ -13,10 +13,8 @@ set -e
 set -o nounset
 set -o pipefail
 
-CURRENTDATE=$(date +"%Y-%m-%d %T")
-
 start_job(){
-    echo "Job started at $CURRENTDATE"
+    echo "Job started at $(date +"%Y-%m-%d %T")"
     echo ".................................."
     echo
 }
@@ -24,7 +22,7 @@ start_job(){
 finish_job(){
     echo
     echo ".................................."
-    echo "Job finished at $CURRENTDATE"
+    echo "Job finished at $(date +"%Y-%m-%d %T")"
 }
 
 ## Function which checks if the node is a Worker node


### PR DESCRIPTION
The previous code was printing same date/time for both start_job and finish_job.

### What type of PR is this?

_bug_

### What this PR does / Why we need it?

This PR is needed to fix the previous code which was printing same date/time for both start_job and finish_job.

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_ No Jira card.

### Special notes for your reviewer

### Pre-checks (if applicable)

- [X] Validated the changes in a cluster
- [ - ] Included documentation changes with PR