### PR TITLE
SREP-861: osdctl network verify-egress in managed-scripts

### DIFF
--- a/scripts/networking/network-verify/README.md
+++ b/scripts/networking/network-verify/README.md
@@ -1,0 +1,92 @@
+# osdctl Network Verifier
+
+This managed script runs network egress verification in pod mode using the pre-installed `osdctl` binary to validate that a ROSA/OSD cluster can reach all required external URLs necessary for full support.
+
+## Overview
+
+The script uses [osd-network-verifier](https://github.com/openshift/osd-network-verifier)'s pod mode to perform network egress testing from within the actual cluster environment. This provides more accurate results compared to traditional cloud instance verification because:
+
+- Tests are performed from within the actual cluster network environment
+- Works correctly with both public and private subnets
+- Doesn't require NAT gateway access like traditional probe instances
+- Validates the exact network path that cluster workloads would use
+
+## What it does
+
+1. **Platform Detection**: Automatically detects the cloud provider (AWS or GCP) from cluster infrastructure.  Note that a flag
+must be passed for HCP or Zero-Egress platform types
+2. **Region Detection**: Automatically detects the region for AWS-based clusters (classic, HCP, or HCP zero egress)
+3. **Pod-based Verification**: Runs network verification using Kubernetes Jobs in the `openshift-network-diagnostics` namespace
+4. **Service Log Skip**: Uses the `--skip-service-log` flag to prevent automatic service log generation
+5. **Binary Usage**: Uses the pre-installed `osdctl` binary from the container image
+
+## Usage
+
+### Basic Usage
+
+```bash
+# Run via OCM backplane (AWS classic clusters)
+ocm backplane managedjob create networking/osdctl-network-verifier
+
+# Check job status
+ocm backplane managedjob list
+
+# View job logs
+ocm backplane managedjob logs <job-id>
+```
+
+### Platform-Specific Usage
+
+The script supports different platform configurations via the `SCRIPT_PARAMETERS` environment variable:
+
+```bash
+# AWS Classic clusters (default - no parameters needed)
+ocm backplane managedjob create networking/osdctl-network-verifier
+
+# HCP (Hosted Control Plane) clusters
+ocm backplane managedjob create networking/osdctl-network-verifier -p SCRIPT_PARAMETERS="--hcp"
+
+# HCP clusters with zero egress configuration
+ocm backplane managedjob create networking/osdctl-network-verifier -p SCRIPT_PARAMETERS="--zero-egress"
+
+# Show help and available parameters
+ocm backplane managedjob create networking/osdctl-network-verifier -p SCRIPT_PARAMETERS="--help"
+```
+
+
+## RBAC Permissions
+
+The script requires the following permissions:
+
+### Cluster-scoped permissions:
+- **Infrastructure**: get (for platform and region detection)
+
+### Namespace-scoped permissions (`openshift-network-diagnostics` only):
+- **Jobs**: get, list, create, delete, watch (for verification jobs)
+- **Pod logs**: get (for debugging verification results)
+
+### Platform and Region Detection
+
+The script automatically detects the cloud provider and platform type:
+
+1. **Cloud Provider Detection**: Queries the cluster infrastructure object to determine if the cluster is running on AWS or GCP
+2. **AWS Platform Types**: 
+   - **Classic** (default): Standard ROSA/OSD clusters
+   - **HCP**: Hosted Control Plane clusters (specified with `--hcp` flag)
+   - **Zero Egress**: HCP clusters with zero egress configuration (specified with `--zero-egress` flag)
+3. **Region Detection**: For AWS-based clusters, automatically detects the region from cluster infrastructure
+4. **GCP Clusters**: Platform type is set to `gcp-classic` (region detection not required for GCP)
+
+### Pod Mode Verification
+
+Pod mode creates Kubernetes Jobs that run verification containers within the cluster. This approach:
+- Uses the cluster's actual network configuration
+- Tests egress through the same network path as cluster workloads
+- Provides accurate results for both public and private subnet configurations
+- Doesn't require external cloud provider credentials
+
+## Related Documentation
+
+- [ROSA Network Prerequisites](https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites)
+- [osd-network-verifier GitHub Repository](https://github.com/openshift/osd-network-verifier)
+- [osdctl GitHub Repository](https://github.com/openshift/osdctl) 

--- a/scripts/networking/network-verify/metadata.yaml
+++ b/scripts/networking/network-verify/metadata.yaml
@@ -1,0 +1,68 @@
+file: script.sh
+name: osdctl-network-verifier
+shortDescription: Runs network egress verification in pod mode using the osdctl binary.
+description: |
+  Runs network egress verification using the osdctl binary and Kubernetes jobs in pod mode.
+  
+  This script verifies that a ROSA/OSD cluster can reach all required external URLs necessary for full support.
+  It uses osd-network-verifier's pod mode which runs verification as Kubernetes Jobs within the target cluster,
+  providing more accurate results as it tests from within the actual cluster environment.
+  
+  Supports multiple platform configurations:
+  - AWS Classic (default): Standard ROSA/OSD clusters
+  - AWS HCP: Hosted Control Plane clusters (use --hcp flag)
+  - AWS HCP Zero Egress: HCP clusters with zero egress (use --zero-egress flag)
+  - GCP Classic: GCP-based clusters (auto-detected)
+  
+  The script automatically:
+  - Detects the cloud provider and platform type from cluster infrastructure
+  - Detects the region for AWS-based clusters
+  - Runs network verification in pod mode with service log sending disabled
+  - Uses the openshift-network-diagnostics namespace for verification pods
+  
+
+  This script requires cluster-level RBAC permissions to read infrastructure and namespace-scoped
+  permissions to create and manage verification pods and jobs.
+
+author: OpenShift SRE
+allowedGroups:
+  - SREP
+  - CEE
+  - MCSTierTwo
+rbac:
+  clusterRoleRules:
+    # Permission to read cluster infrastructure for region detection (must be cluster-scoped)
+    - verbs:
+        - "get"
+      apiGroups:
+        - "config.openshift.io"
+      resources:
+        - "infrastructures"
+  roles:
+    # Permissions scoped to openshift-network-diagnostics namespace only
+    - namespace: "openshift-network-diagnostics"
+      rules:
+        # Permissions for jobs - needed to create and manage Kubernetes jobs for verification
+        - verbs:
+            - "get"
+            - "list"
+            - "create"
+            - "delete"
+            - "watch"
+          apiGroups:
+            - "batch"
+          resources:
+            - "jobs"
+        # Permission to read pod logs for debugging verification results
+        - verbs:
+            - "get"
+          apiGroups:
+            - ""
+          resources:
+            - "pods/log"
+envs:
+  - key: "SCRIPT_PARAMETERS"
+    description: "Platform configuration parameters. Use '--hcp' for Hosted Control Plane clusters, '--zero-egress' for HCP zero egress clusters, or '--help' for usage information. Leave empty for AWS Classic or GCP clusters."
+    optional: true
+language: bash
+customerDataAccess: false

--- a/scripts/networking/network-verify/script.sh
+++ b/scripts/networking/network-verify/script.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+#
+# Description: Runs network egress verification in pod mode using the pre-installed osdctl binary.
+
+set -euo pipefail
+
+# Global variables
+readonly NAMESPACE="openshift-network-diagnostics"
+readonly OSDCTL_BINARY="osdctl"
+readonly LOG_INFO="INFO:"
+readonly LOG_ERROR="ERROR:"
+readonly LOG_WARN="WARNING:"
+
+# Global variables set by detect_platform_and_region()
+REGION=""
+PLATFORM=""
+HCP_CLUSTER=false
+ZERO_EGRESS=false
+
+# Parse script parameters (follows managed-scripts convention)
+parse_script_parameters() {
+    # If SCRIPT_PARAMETERS is not set, nothing to parse
+    if [[ -z "${SCRIPT_PARAMETERS:-}" ]]; then
+        return 0
+    fi
+    
+    # Split SCRIPT_PARAMETERS into array
+    IFS=' ' read -r -a ARG_ARRAY <<< "${SCRIPT_PARAMETERS}"
+    
+    # Parse arguments
+    for ARG in "${ARG_ARRAY[@]}"; do
+        if [[ "$ARG" == "--hcp" ]]; then
+            HCP_CLUSTER=true
+        elif [[ "$ARG" == "--zero-egress" ]]; then
+            ZERO_EGRESS=true
+        elif [[ "$ARG" == "-h" || "$ARG" == "--help" ]]; then
+            echo "Usage: SCRIPT_PARAMETERS=\"[--hcp] [--zero-egress]\""
+            echo "  --hcp           Specify that this is an HCP (Hosted Control Plane) cluster"
+            echo "  --zero-egress   Specify that this is an HCP cluster with zero egress configuration"
+            exit 0
+        else
+            echo "$LOG_ERROR Unknown parameter: $ARG"
+            echo "$LOG_INFO Valid parameters: --hcp, --zero-egress, --help"
+            exit 1
+        fi
+    done
+}
+
+# Validate environment for Kubernetes access
+validate_environment() {
+    # Check if running in a pod with service account
+    if [[ -f "/var/run/secrets/kubernetes.io/serviceaccount/token" ]]; then
+        echo "$LOG_INFO Running in pod with ServiceAccount token"
+        return 0
+    fi
+    
+    # Check if oc is available and logged in
+    if command -v oc &> /dev/null; then
+        if oc whoami &> /dev/null; then
+            echo "$LOG_INFO Logged into OpenShift cluster via oc"
+            return 0
+        fi
+    fi
+    
+    echo "$LOG_ERROR Must be running in a pod with ServiceAccount token or logged into OpenShift cluster"
+    return 1
+}
+
+
+
+# Detect the cloud provider and platform from cluster metadata
+detect_platform_and_region() {
+    local cloud_provider=""
+
+    # Try to get cloud provider from cluster infrastructure
+    cloud_provider=$(oc get infrastructure cluster -o jsonpath='{.status.platform}' 2>/dev/null || echo "")
+    
+    if [[ -z "$cloud_provider" ]]; then
+        echo "$LOG_ERROR Could not determine cloud provider from cluster infrastructure" >&2
+        return 1
+    fi
+    
+    case "$cloud_provider" in
+        "AWS")
+            if [[ "$ZERO_EGRESS" == true ]]; then
+                PLATFORM="aws-hcp-zeroegress"
+            elif [[ "$HCP_CLUSTER" == true ]]; then
+                PLATFORM="aws-hcp"
+            else
+                PLATFORM="aws-classic"
+            fi
+            
+            REGION=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus.aws.region}' 2>/dev/null || echo "")
+            if [[ -z "$REGION" ]]; then
+                echo "$LOG_ERROR Could not determine AWS region" >&2
+                return 1
+            fi
+            ;;
+        "GCP")
+            PLATFORM="gcp-classic"
+            ;;
+        *)
+            echo "$LOG_ERROR Unsupported cloud provider: $cloud_provider" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Run network verification in pod mode
+run_network_verification() {
+    # Get platform and region (if applicable)
+    if ! detect_platform_and_region; then
+        echo "$LOG_ERROR Failed to detect platform"
+        return 1
+    fi
+    
+    if [[ -z "$PLATFORM" ]]; then
+        echo "$LOG_ERROR Invalid platform detected: '$PLATFORM'"
+        return 1
+    fi
+    
+    echo "$LOG_INFO Running network egress verification in pod mode..."
+    if [[ -n "$REGION" ]]; then
+        echo "$LOG_INFO Using platform: $PLATFORM, region: $REGION"
+    else
+        echo "$LOG_INFO Using platform: $PLATFORM"
+    fi
+    
+    # Create a writable config directory for osdctl
+    local config_dir="/tmp/osdctl-config"
+    mkdir -p "$config_dir"
+    
+    # Set environment variables for osdctl configuration
+    export HOME="/tmp"
+    export XDG_CONFIG_HOME="$config_dir"
+    export XDG_CACHE_HOME="/tmp/cache"
+    export XDG_DATA_HOME="/tmp/data"
+    
+    # Build command arguments
+    local cmd_args=(
+        "network"
+        "verify-egress"
+        "--pod-mode"
+        "--platform" "$PLATFORM"
+        "--skip-service-log"
+        "--namespace" "$NAMESPACE"
+    )
+    
+    # Add region flag only for AWS
+    if [[ -n "$REGION" ]]; then
+        cmd_args+=("--region" "$REGION")
+    fi
+    
+    echo "$LOG_INFO ============================================"
+    echo "$LOG_INFO Network Verification Output:"
+    echo "$LOG_INFO ============================================"
+    
+    # Run the command and capture both output and exit code
+    local output exit_code
+    output=$("$OSDCTL_BINARY" "${cmd_args[@]}" 2>&1)
+    exit_code=$?
+    
+    # Display the output
+    echo "$output"
+    
+    echo "$LOG_INFO ============================================"
+    echo "$LOG_INFO End of Network Verification Output"
+    echo "$LOG_INFO ============================================"
+    
+    if [[ $exit_code -ne 0 ]]; then
+        echo "$LOG_ERROR Network verification failed with exit code: $exit_code"
+        return 1
+    fi
+    
+    echo "$LOG_INFO Network verification completed successfully"
+}
+
+main() {
+    echo "$LOG_INFO Starting osdctl network verification script"
+    
+    # Parse script parameters
+    parse_script_parameters
+    
+    if ! validate_environment; then
+        echo "$LOG_ERROR Environment validation failed"
+        exit 1
+    fi
+    
+    if ! run_network_verification; then
+        echo "$LOG_ERROR Network verification failed"
+        exit 1
+    fi
+    
+    echo "$LOG_INFO Network verification script completed successfully"
+    exit 0
+}
+
+main "$@" 


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / Why we need it?
https://issues.redhat.com/browse/SREP-861

_Resolves #_
Allows MCS to use osdctl network-verify in pod mode with a service account

### Logs from running against an AWS cluster
```
$ ocm backplane testjob create -c $CLUSTER_ID

Test job openshift-job-dev-gd6mf created successfully

Run "ocm backplane testjob get openshift-job-dev-gd6mf" for details
Run "ocm backplane testjob logs openshift-job-dev-gd6mf" for job logs
```
	
TestId: openshift-job-dev-gd6mf

```
$ ocm backplane testjob logs openshift-job-dev-gd6mf
INFO: Starting osdctl network verification script
INFO: Running in pod with ServiceAccount token
INFO: Downloading latest osdctl binary...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 39.2M  100 39.2M    0     0   122M      0 --:--:-- --:--:-- --:--:--  122M
INFO: Running network egress verification in pod mode...
INFO: Using platform: aws-classic, region: us-east-1
INFO: ============================================
INFO: Network Verification Output:
INFO: ============================================
2025/08/21 18:55:01 Preparing to run pod-based network verification in namespace openshift-network-diagnostics.
2025/08/21 18:55:01 Pod mode using in-cluster configuration with ServiceAccount
2025/08/21 18:55:01 Pod mode initialized with namespace: openshift-network-diagnostics
2025/08/21 18:55:01 Using manually specified AWS region: us-east-1
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/aws-classic.yaml?ref=main at SHA 997186fa8fbf863db4b071d246e7bb781bc1e796
Summary:
All tests passed!
INFO: ============================================
INFO: End of Network Verification Output
INFO: ============================================
INFO: Network verification completed successfully
INFO: Network verification script completed successfully
```

### Logs from running against a GCP cluster
```
$ ocm backplane testjob create -c $CLUSTER_ID

	Test job openshift-job-dev-94w4t created successfully

	Run "ocm backplane testjob get openshift-job-dev-94w4t" for details
	Run "ocm backplane testjob logs openshift-job-dev-94w4t" for job logs
	
TestId: openshift-job-dev-94w4t
```
```
$ ocm backplane testjob logs openshift-job-dev-94w4t
INFO: Starting osdctl network verification script
INFO: Running in pod with ServiceAccount token
INFO: Downloading latest osdctl binary...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 39.2M  100 39.2M    0     0  85.3M      0 --:--:-- --:--:-- --:--:--  125M
INFO: Running network egress verification in pod mode...
INFO: Using platform: gcp-classic, region: us-east1
INFO: ============================================
INFO: Network Verification Output:
INFO: ============================================
2025/08/21 18:53:36 Preparing to run pod-based network verification in namespace openshift-network-diagnostics.
2025/08/21 18:53:36 Pod mode using in-cluster configuration with ServiceAccount
2025/08/21 18:53:36 Pod mode initialized with namespace: openshift-network-diagnostics
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/gcp-classic.yaml?ref=main at SHA 75a9bc6139ceaa2434be34b87bb4aa9570023630
Summary:
All tests passed!
INFO: ============================================
INFO: End of Network Verification Output
INFO: ============================================
INFO: Network verification completed successfully
INFO: Network verification script completed successfully
```

### Logs from running against an HCP cluster
```$ ocm backplane testjob create -c $CLUSTER_ID -p SCRIPT_PARAMETERS="--hcp"

	Test job openshift-job-dev-rrx24 created successfully

	Run "ocm backplane testjob get openshift-job-dev-rrx24" for details
	Run "ocm backplane testjob logs openshift-job-dev-rrx24" for job logs
	
TestId: openshift-job-dev-rrx24
dalong@dalong-thinkpadp16vgen1:~/projects/openshift/managed-scripts/scripts/networking/network-verify$ ocm backplane testjob logs openshift-job-dev-rrx24
INFO: Starting osdctl network verification script
INFO: Running in pod with ServiceAccount token
INFO: Downloading latest osdctl binary...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 39.2M  100 39.2M    0     0   149M      0 --:--:-- --:--:-- --:--:--  493M
INFO: Running network egress verification in pod mode...
INFO: Using platform: aws-hcp, region: us-east-1
INFO: ============================================
INFO: Network Verification Output:
INFO: ============================================
2025/08/25 16:24:54 Preparing to run pod-based network verification in namespace openshift-network-diagnostics.
2025/08/25 16:24:54 Pod mode using in-cluster configuration with ServiceAccount
2025/08/25 16:24:54 Pod mode initialized with namespace: openshift-network-diagnostics
2025/08/25 16:24:54 Using manually specified AWS region: us-east-1
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/aws-hcp.yaml?ref=main at SHA 1cb7c15e951908f44d5ff3b3589ec763cea917c9
Summary:
All tests passed!
INFO: ============================================
INFO: End of Network Verification Output
INFO: ============================================
INFO: Network verification completed successfully
INFO: Network verification script completed successfully
```

### Logs from running against a Zero Egress cluster
```$ ocm backplane testjob create -c $CLUSTER_ID -p SCRIPT_PARAMETERS="--zero-egress"

	Test job openshift-job-dev-227dm created successfully

	Run "ocm backplane testjob get openshift-job-dev-227dm" for details
	Run "ocm backplane testjob logs openshift-job-dev-227dm" for job logs
	
TestId: openshift-job-dev-227dm
dalong@dalong-thinkpadp16vgen1:~/projects/openshift/managed-scripts/scripts/networking/network-verify$ ocm backplane testjob logs openshift-job-dev-227dm
INFO: Starting osdctl network verification script
INFO: Running in pod with ServiceAccount token
INFO: Downloading latest osdctl binary...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 39.2M  100 39.2M    0     0   156M      0 --:--:-- --:--:-- --:--:--  307M
INFO: Running network egress verification in pod mode...
INFO: Using platform: aws-hcp-zeroegress, region: us-east-1
INFO: ============================================
INFO: Network Verification Output:
INFO: ============================================
2025/08/25 16:25:48 Preparing to run pod-based network verification in namespace openshift-network-diagnostics.
2025/08/25 16:25:48 Pod mode using in-cluster configuration with ServiceAccount
2025/08/25 16:25:48 Pod mode initialized with namespace: openshift-network-diagnostics
2025/08/25 16:25:48 Using manually specified AWS region: us-east-1
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/aws-hcp-zeroegress.yaml?ref=main at SHA 8350d3f1d46c6046795cbfd9b59095ba593732a3
Summary:
All tests passed!
INFO: ============================================
INFO: End of Network Verification Output
INFO: ============================================
INFO: Network verification completed successfully
INFO: Network verification script completed successfully
```

- [X] Validated the changes in a cluster
- [X] Included documentation changes with PR