### PR TITLE
Remove duplicate test exection caused by pipelinesascode

### DIFF
--- a/.tekton/pr-check-pipeline.yaml
+++ b/.tekton/pr-check-pipeline.yaml
@@ -2,9 +2,6 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: pr-check
-  annotations:
-    pipelinesascode.tekton.dev/on-event: "[pull_request]"
-    pipelinesascode.tekton.dev/on-target-branch: "[main]"
 spec:
   pipelineSpec:
     params:


### PR DESCRIPTION
The PR check pipeline is trigger by a integrationtestscenario in konflux. 
These annotations caused it to be executed twice.

### What type of PR is this?
bug
