### PR TITLE
Fix osdctl tar extraction failing on ownership change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ RUN export OSDCTL_LINUX_X86_TARBALL=$(cat sha256sum.txt | grep "Linux_x86_64" | 
 RUN sha256sum --check --ignore-missing sha256sum.txt
 
 # Extract the specific osdctl tarball and move the validated osdctl binary to /out
-RUN tar -xzf $(cat tarball_name.txt)
+RUN tar --no-same-owner -xzf $(cat tarball_name.txt)
 RUN mv osdctl /out/osdctl
 RUN chmod +x /out/osdctl
 


### PR DESCRIPTION
Add --no-same-owner to the osdctl tar command to prevent failure when the release tarball contains files with UIDs that don't exist in the container (uid 4208549, gid 4208549).

### What type of PR is this?

bug

### What this PR does / Why we need it?

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration to improve file extraction handling and ensure consistent file permissions during the package setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->