### PR TITLE
Bumping ubi images to 8.10-1779891713

### DIFF
--- a/.tekton/pr-check-pipeline.yaml
+++ b/.tekton/pr-check-pipeline.yaml
@@ -23,7 +23,7 @@ spec:
             description: Git revision from SNAPSHOT
         steps:
           - name: parse
-            image: registry.access.redhat.com/ubi8/ubi:8.10-1778769589@sha256:1551c9a922dbb31c5688380fd955ef57f0f00b395bacb36856bc386eba82897b
+            image: registry.access.redhat.com/ubi8/ubi:8.10-1779891713@sha256:2dc62269ba3457072db8da29df4ddfd6176b33904b44664c1e59005cb99a8c25
             script: |
               #!/bin/bash
               set -ex
@@ -69,7 +69,7 @@ spec:
           - name: source
         steps:
           - name: validation
-            image: registry.access.redhat.com/ubi8/ubi:8.10-1778769589@sha256:1551c9a922dbb31c5688380fd955ef57f0f00b395bacb36856bc386eba82897b
+            image: registry.access.redhat.com/ubi8/ubi:8.10-1779891713@sha256:2dc62269ba3457072db8da29df4ddfd6176b33904b44664c1e59005cb99a8c25
             workingDir: $(workspaces.source.path)/source
             script: |
               #!/bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.10-1770785762 AS build-stage0
+FROM registry.access.redhat.com/ubi8/ubi:8.10-1779891713 AS build-stage0
 
 ARG OC_VERSION="stable-4.15"
 ENV OC_URL="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OC_VERSION}"
@@ -146,7 +146,7 @@ RUN chmod +x /out/osdctl
 # Make binaries executable
 RUN chmod -R +x /out
 
-FROM registry.access.redhat.com/ubi8/ubi:8.10-1770785762
+FROM registry.access.redhat.com/ubi8/ubi:8.10-1779891713
 RUN  yum -y install \
      python3.11 python3.11-pip jq openssh-clients sshpass \
      && yum clean all

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMAGE_VERSION=$(shell git rev-parse --short=7 HEAD)
 IMAGE_URI=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME)
 IMAGE_URI_VERSION=$(IMAGE_URI):$(IMAGE_VERSION)
 IMAGE_URI_LATEST=$(IMAGE_URI):latest
-SHELL_CHECK_IMAGE="registry.access.redhat.com/ubi8/ubi:8.9"
+SHELL_CHECK_IMAGE="registry.access.redhat.com/ubi8/ubi:8.10-1779891713"
 PYTHON_IMAGE="registry.access.redhat.com/ubi8/python-36:latest"
 
 CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)


### PR DESCRIPTION
### What type of PR is this?

cleanup

### What this PR does / Why we need it?

New ubi images are available

### Which Jira/Github issue(s) does this PR fix?

Related to [OSD-32760](https://redhat.atlassian.net/browse/OSD-32760)

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a cluster
- [x] Included documentation changes with PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base container images to the latest stable versions across multiple build pipelines, validation, and testing environments to ensure improved security, performance, and long-term compatibility.
  * Refreshed container image dependencies to maintain consistent and stable operations across all development infrastructure and tooling systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->