### PR TITLE
[Project Darkstar] ROSAENG-61595: Remediate CVE-2026-15308 in managed-scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.10-1779891713 AS build-stage0
+FROM registry.access.redhat.com/ubi8/ubi:8.10-1781720109 AS build-stage0
 
 ARG OC_VERSION="stable-4.15"
 ENV OC_URL="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OC_VERSION}"
@@ -146,7 +146,7 @@ RUN chmod +x /out/osdctl
 # Make binaries executable
 RUN chmod -R +x /out
 
-FROM registry.access.redhat.com/ubi8/ubi:8.10-1779891713
+FROM registry.access.redhat.com/ubi8/ubi:8.10-1781720109
 RUN  yum -y install \
      python3.11 python3.11-pip jq openssh-clients sshpass \
      && yum clean all


### PR DESCRIPTION
## Project Darkstar — Automated CVE Remediation

> **This PR was generated by Project Darkstar**, an automated CVE remediation tool.
> For questions or concerns, contact **Kevin Seiter** (ROSA Trust Engineering).

## Summary
- Fixes CVE-2026-15308 (Important, CVSS 7.5) — Python CPU DoS in html.parser
- Updates UBI8 base image from `8.10-1779891713` to `8.10-1781720109` in both Dockerfile stages
- Aligns Dockerfile with the tag already used in `.tekton/pr-check-pipeline.yaml`

## CVE Details
- **CVE:** CVE-2026-15308
- **Severity:** Important (CVSS 7.5)
- **CWE:** CWE-835 (Uncontrolled Loop / Infinite Loop)
- **Description:** Python's `html.parser.HTMLParser` allows CPU denial-of-service via repeated unterminated markup declarations in uncontrolled input.
- **Fix:** Red Hat backported the fix to python3.11 (RHSA-2026:38017/38018). Updating the UBI8 base image tag triggers a rebuild that pulls the patched python3.11 RPM from Red Hat's online repos.

## CVEs Analyzed But Not Auto-Fixed (require action outside this repo)

| CVE | Severity | Component | Reason |
|-----|----------|-----------|--------|
| CVE-2026-44740 | Important (7.5) | go-billy v5 | Transitive dep in hypershift — fix in openshift/hypershift go.mod |
| CVE-2026-53492 | Important (8.2) | containerd CRI plugin | Runtime-level — update containerd at cluster/node level |
| CVE-2026-53488 | Important (8.8) | containerd CRI plugin | Runtime-level — update containerd at cluster/node level |
| CVE-2026-42306 | Important (7.2) | Moby/Docker Engine | Runtime-level — update Docker Engine to 29.5.1 |

## Changes
- `Dockerfile`: Updated both `FROM` lines from `ubi8/ubi:8.10-1779891713` to `ubi8/ubi:8.10-1781720109`

## Verification
- [ ] CI/CD pipeline (`make build`) passes with new base image
- [ ] No regressions in existing script validation
- [ ] New base image tag is on the same 8.10 major.minor stream

## References
- Jira: [ROSAENG-61595](https://redhat.atlassian.net/browse/ROSAENG-61595)
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-15308
- RHSA: https://access.redhat.com/errata/RHSA-2026:38017

---
**Project Darkstar** — Automated CVE Remediation | Contact: Kevin Seiter (ROSA Trust Engineering)